### PR TITLE
Docker support for minimal environment.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+ 
+NODE_ENV=${NODE_ENV:-production}
+
+yarn prisma migrate deploy
+
+exec "$@"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,18 +25,23 @@ RUN apt-get -yqq update && apt-get install -yqq --no-install-recommends curl gnu
     && useradd --uid 1000 --gid 1000 -m node
 
 COPY --chown=node:node --from=builder /app/node_modules /app/node_modules
+COPY --chown=node:node --from=builder /root/.cache/ms-playwright /home/node/.cache/ms-playwright
 COPY --chown=node:node . /app
 
 WORKDIR /app
 
 # This installs playwright dependencies on Ubuntu APT repositories.
+# Also prepare the `data` directory for node user.
 RUN npx playwright install-deps \
     && rm -rf /var/lib/apt/lists/* \
-    && npx next telemetry disable \
-    && yarn build
+    && mkdir /app/data \
+    && chown -R node:node /app/data
 
 # Start the app as a non-privileged user.
 USER node
+
+RUN npx next telemetry disable \
+    && yarn build
 
 # The entrypoint plays prisma migrations before starting whatever command the user wants (defaults to `yarn start`).
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:latest as builder
+
+WORKDIR /app
+
+COPY . /app/
+
+RUN yarn install
+
+# Ubuntu is needed for playwright.
+FROM ubuntu:22.04 as app
+
+ENV NODE_ENV production
+ARG DEBIAN_FRONTEND noninteractive
+
+# Installs nodejs and yarn latest version through node/yarn repositories.
+# Creates 'node' unprivileged user with uid/gid 1000 (the same as in "node" official docker image).
+RUN apt-get -yqq update && apt-get install -yqq --no-install-recommends curl gnupg ca-certificates lsb-release dialog apt-utils \
+    && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x jammy main' > /etc/apt/sources.list.d/nodesource.list \
+    && echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x jammy main' >> /etc/apt/sources.list.d/nodesource.list \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get -yqq update && apt-get install -yqq --no-install-recommends nodejs yarn \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid 1000 -m node
+
+COPY --chown=node:node --from=builder /app/node_modules /app/node_modules
+COPY --chown=node:node . /app
+
+WORKDIR /app
+
+# This installs playwright dependencies on Ubuntu APT repositories.
+RUN npx playwright install-deps \
+    && rm -rf /var/lib/apt/lists/* \
+    && npx next telemetry disable \
+    && yarn build
+
+# Start the app as a non-privileged user.
+USER node
+
+# The entrypoint plays prisma migrations before starting whatever command the user wants (defaults to `yarn start`).
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["yarn", "start"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,52 @@
+# docker files
+docker/
+
+# git stuff
+.git
+.gitignore
+.github
+
+# misc
+.DS_Store
+*.pem
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# generated files and folders
+/data
+
+# tests
+/tests
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+--- 
+version: '3.8'
+services:
+  linkwarden:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    container_name: linkwarden-app
+    restart:  always
+    ports:
+      - '3000:3000'
+    environment:
+      NEXTAUTH_SECRET: SuperSecret!
+      NEXTAUTH_URL: http://localhost:3000
+      DATABASE_URL: postgresql://postgres:postgres@linkwarden-postgres:5432/linkwarden
+    depends_on:
+      - postgres
+
+  postgres:
+    container_name: linkwarden-postgres
+    image: postgres:14.1-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - '5432:5432'
+    volumes: 
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:
+    driver: local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       NEXTAUTH_URL: http://localhost:3000
       DATABASE_URL: postgresql://postgres:postgres@linkwarden-postgres:5432/linkwarden
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    volumes:
+      - app-data:/app/data
 
   postgres:
     container_name: linkwarden-postgres
@@ -27,6 +30,15 @@ services:
       - '5432:5432'
     volumes: 
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 volumes:
   postgres-data:
     driver: local
+    name: linkwarden-postgres-data
+  app-data:
+    driver: local
+    name: linkwarden-app-data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+    user: postgres
     ports:
       - '5432:5432'
     volumes: 


### PR DESCRIPTION
Hello,

I just saw the other PR but I thought I'd submit my work too so you can chose whatever implementation you prefer :-).

We may be able to improve the Dockerfile "builder" stage by copying only the files needed for yarn install (I tried with only `package.json` and `yarn.lock` but it was not enough, playwright didn't build, I guess it needs the ts files too).

I chose to build from node:latest to have a complete building image (including gcc and stuff, if needed for compiling) and serve the app on a standard ubuntu image (ubuntu is needed for playwright), also I'm starting the app with the `node` user rather than root, for basic security.

Also I'm using environment in the docker-compose rather than the .env file for easier modifications (modify compose, and `docker-compose -f docker/docker-compose.yml up -d`).

Ask for any change or close this PR if you don't need it :-).

Thanks for the good work on the app !!
-- 
Zeylos