### PR TITLE
Added support for other database providers

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
 NEXTAUTH_SECRET=very_sensitive_secret
+#DATABASE_PROVIDER=sqlite
+#DATABASE_URL=file:./data.db
+DATABASE_PROVIDER=postgresql
 DATABASE_URL=postgresql://user:password@localhost:5432/linkwarden
 NEXTAUTH_URL=http://localhost:3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:18.18-bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG DATABASE_PROVIDER
 
 RUN mkdir /data
 
@@ -16,6 +17,8 @@ RUN npx playwright install-deps && \
     yarn cache clean
 
 COPY . .
+
+RUN sed -i "s/DATABASE_PROVIDER/${DATABASE_PROVIDER}/g" ./prisma/schema.prisma
 
 RUN yarn prisma generate && \
     yarn build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,5 @@
 version: "3.5"
 services:
-  postgres:
-    image: postgres
-    env_file: .env
-    restart: always
-    volumes:
-      - ./pgdata:/var/lib/postgresql/data
   linkwarden:
     env_file: .env
     environment:
@@ -16,5 +10,3 @@ services:
       - 3000:3000
     volumes:
       - ./data:/data/data
-    depends_on:
-      - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: "3.5"
 services:
   linkwarden:
     env_file: .env
-    environment:
-      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     restart: always
     image: ghcr.io/linkwarden/linkwarden:latest
     ports:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "DATABASE_PROVIDER"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
- Updated `.env.sample` to add a database provider variable
- Modified `Dockerfile` so the database provider is injected in Prisma's schema
- Modified Prisma's schema to add a placeholder where the database provider can be injected
- Removed Postgres dependency from `docker-compose`