### PR TITLE
Update docker-compose.yml - link /data to map /data/archives and /data/uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./data:/data/data
+      - ./data:/data
     depends_on:
       - postgres


### PR DESCRIPTION
link the entire data dir

otherwise /data/archives and /data/uploads goes into docker.img ! my linkwarden docker container was taking over 2 GB because the archives were not mapped

![image](https://github.com/linkwarden/linkwarden/assets/609213/d9ea3e82-e861-4d64-929d-f25704311ff8)


`du` in the container
![image](https://github.com/linkwarden/linkwarden/assets/609213/39bd4521-1eaa-4c05-9b32-739f09830cdd)

