### PR TITLE
Add support for local Cookies file

### DIFF
--- a/lib/api/archiveHandler.ts
+++ b/lib/api/archiveHandler.ts
@@ -10,6 +10,7 @@ import validateUrlSize from "./validateUrlSize";
 import removeFile from "./storage/removeFile";
 import Jimp from "jimp";
 import createFolder from "./storage/createFolder";
+import fs from "fs";
 
 type LinksAndCollectionAndOwner = Link & {
   collection: Collection & {
@@ -36,6 +37,7 @@ export default async function archiveHandler(link: LinksAndCollectionAndOwner) {
     ...devices["Desktop Chrome"],
     ignoreHTTPSErrors: process.env.IGNORE_HTTPS_ERRORS === "true",
   });
+  const cookiesFilePath = '/data/data/cookies.txt';
 
   const page = await context.newPage();
 
@@ -111,7 +113,20 @@ export default async function archiveHandler(link: LinksAndCollectionAndOwner) {
           return;
         } else if (link.url) {
           // archive url
-
+          
+          // Check if cookies file exists
+          if (fs.existsSync(cookiesFilePath)) {
+            const cookies = parseCookiesFromFile(cookiesFilePath);
+            if (cookies.length > 0) {
+              try {
+                await context.addCookies(cookies);
+              } catch (error) {
+                console.error("Error adding cookies:", error);
+              }
+            }
+          } else {
+            console.warn(`Cookies file not found at path: ${cookiesFilePath}`);
+          }
           await page.goto(link.url, { waitUntil: "domcontentloaded" });
 
           const content = await page.content();
@@ -412,3 +427,26 @@ const pdfHandler = async ({ url, id }: Link) => {
     });
   }
 };
+
+function parseCookiesFromFile(filePath: string) {
+  const rawCookies = fs.readFileSync(filePath, 'utf-8').split('\n').slice(4); // Skip the header lines
+  const cookies = rawCookies.map(line => {
+    const [domain, , path, secure, expiry, name, value] = line.split(/\s+/);
+
+    if (!domain || !path || !secure || !expiry || !name || !value) {
+      console.warn(`Skipping malformed cookie line: ${line}`);
+      return null;
+    }
+
+    return {
+      name: name,
+      value: value,
+      domain: domain,
+      path: path,
+      secure: secure.toLowerCase() === 'true',
+      expires: expiry === '0' ? undefined : Number(expiry)
+    };
+  }).filter(cookie => cookie !== null); // Filter out null values
+
+  return cookies as { name: string, value: string, domain: string, path: string, secure: boolean, expires?: number }[];
+}

--- a/lib/api/archiveHandler.ts
+++ b/lib/api/archiveHandler.ts
@@ -127,6 +127,7 @@ export default async function archiveHandler(link: LinksAndCollectionAndOwner) {
           } else {
             console.warn(`Cookies file not found at path: ${cookiesFilePath}`);
           }
+          
           await page.goto(link.url, { waitUntil: "domcontentloaded" });
 
           const content = await page.content();


### PR DESCRIPTION
When creating preserved formats, a lot of sites will ask for login and create a big pop-up window for it, a big chunk of the website could be covered by that window like the following example:
![image](https://github.com/linkwarden/linkwarden/assets/12467320/8dd15b8f-d214-4080-b3f5-873b6717dca9)

To avoid that, the new code will load a cookies file at /data/data/cookies.txt, which is the data folder for the container image.
So, when taking a snapshot, the playwright will log in with cookies automatically to avoid pop-up for login. when set up properly could also avoid pop-up for cookies permissions and all sorts of other things as well.
cookies file needs to be in the standard format that can be extracted by this extension for Chrome/Edge:
[Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/cclelndahbckbenkjhflpdbgdldlbecc)

Here is the snapshot of the same webpage as the previous example after the cookies are loaded:
![image](https://github.com/linkwarden/linkwarden/assets/12467320/572f05f1-9701-4a74-aea5-a211db023ee0)
