### PR TITLE
fix: reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,9 @@ RUN --mount=type=cache,sharing=locked,target=/usr/local/share/.cache/yarn \
 COPY --from=monolith-builder /usr/local/cargo/bin/monolith /usr/local/bin/monolith
 
 RUN set -eux && \
-    npx playwright install-deps && \
+    npx playwright install --with-deps chromium && \
     apt-get clean && \
     yarn cache clean
-
-RUN yarn playwright install
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM node:18.18-bullseye-slim
+# Stage: monolith-builder
+# Purpose: Uses the Rust image to build monolith
+# Notes:
+#  - Fine to leave extra here, as only the resulting binary is copied out
+FROM docker.io/rust:1.80-bullseye AS monolith-builder
+
+RUN set -eux && cargo install --locked monolith
+
+# Stage: main-app
+# Purpose: Compiles the frontend and
+# Notes:
+#  - Nothing extra should be left here.  All commands should cleanup
+FROM node:18.18-bullseye-slim AS main-app
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -8,25 +20,15 @@ WORKDIR /data
 
 COPY ./package.json ./yarn.lock ./playwright.config.ts ./
 
-RUN --mount=type=cache,sharing=locked,target=/usr/local/share/.cache/yarn yarn install --network-timeout 10000000
+RUN --mount=type=cache,sharing=locked,target=/usr/local/share/.cache/yarn \
+    set -eux && \
+    yarn install --network-timeout 10000000
 
-RUN apt-get update
+# Copy the compiled monolith binary from the builder stage
+COPY --from=monolith-builder /usr/local/cargo/bin/monolith /usr/local/bin/monolith
 
-RUN apt-get install -y \
-    build-essential \
-    curl \
-    libssl-dev \
-    pkg-config
-
-RUN apt-get update
-
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-RUN cargo install monolith
-
-RUN npx playwright install-deps && \
+RUN set -eux && \
+    npx playwright install-deps && \
     apt-get clean && \
     yarn cache clean
 


### PR DESCRIPTION
Consider this a simplified initial base that #637 could build upon for the frontend in particular.

The main change here is to build the `monolith` binary in a seperate stage and copy it to the final stage.  This means all users do not get a complete install of Rust, `build-essential`, etc, as none of that is required to run the binary.

This shaves about 40% off the image size:
```
linkwarden                                   local            49fb760b02e4   22 seconds ago   2.82GB
ghcr.io/linkwarden/linkwarden                latest           3b3bee162793   9 days ago       4.35GB
```