### PR TITLE
Chore: Updates actions to their latest versions

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -59,10 +59,10 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: 'yarn'
@@ -135,7 +135,7 @@ jobs:
       - name: Run Tests
         run: npx playwright test --grep ${{ matrix.test_case }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
No problems building or testing:
- https://github.com/stumpylog/linkwarden/actions/runs/10239661604
- https://github.com/stumpylog/linkwarden/actions/runs/10241140570

Will eliminate the current warnings.

If helpful, I could configure dependabot for monthly checks of action updates