### PR TITLE
Allow running docker images as non-root user

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,10 @@ DATABASE_URL=
 # Docker installation database settings
 POSTGRES_PASSWORD=
 
+# Run processes inside container as specific user
+UID=1000
+GID=1000
+
 # Additional Optional Settings
 PAGINATION_TAKE_COUNT=
 STORAGE_FOLDER=

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux && cargo install --locked monolith
 FROM node:18.18-bullseye-slim AS main-app
 
 ARG DEBIAN_FRONTEND=noninteractive
+ENV PLAYWRIGHT_BROWSERS_PATH=/data/.cache/ms-playwright
 
 RUN mkdir /data
 
@@ -35,7 +36,8 @@ RUN set -eux && \
 COPY . .
 
 RUN yarn prisma generate && \
-    yarn build
+    yarn build && \
+    chmod -R u+rwX,o+rwX,g+rwX /data
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.5"
 services:
   postgres:
     image: postgres:16-alpine
+    user: ${UID:-1000}:${GID:-1000}
     env_file: .env
     restart: always
     volumes:
@@ -13,6 +14,7 @@ services:
     restart: always
     # build: . # uncomment this line to build from source
     image: ghcr.io/linkwarden/linkwarden:latest # comment this line to build from source
+    user: ${UID:-1000}:${GID:-1000}
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
This changes permissions inside the docker image in order to be able to run linkwarden without root permissions.

I decided against creating a special-purpose user as proposed in #701, because this would be a breaking change for existing installs (requires changes to ownership of existing bind-mounts). Instead, I've added configuration to docker-compose.yml that new installs will pick up and allows customization by the user.

Fixes #550
Fixes #655 
Fixes #712 
