### PR TITLE
Allow to specify query log level

### DIFF
--- a/lib/api/db.ts
+++ b/lib/api/db.ts
@@ -1,11 +1,11 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 export const prisma =
   globalForPrisma.prisma ||
   new PrismaClient({
-    log: ["query"],
+    log: [process.env.LINKWARDEN_QUERY_LOG_LEVEL as Prisma.LogLevel || "query"],
   });
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
While nice for debugging, during normal operations printing all SQL queries just spams the log (especially when using a log aggregator)