### PR TITLE
Remove duplicated URL if existing (MacOS Shortcut), fixes #551

### DIFF
--- a/lib/api/controllers/links/postLink.ts
+++ b/lib/api/controllers/links/postLink.ts
@@ -10,6 +10,10 @@ export default async function postLink(
   link: LinkIncludingShortenedCollectionAndTags,
   userId: number
 ) {
+
+  const trimUrl = link.url?.replace(/\n.*$/, "") || null;
+  link.url = trimUrl;
+
   if (link.url || link.type === "url") {
     try {
       new URL(link.url || "");


### PR DESCRIPTION
Remove everything after a \n in the url via api submission. Please check the fix as my typescript skills are non-existent.
