### PR TITLE
Adding healthcheck to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ COPY . .
 RUN yarn prisma generate && \
     yarn build
 
+HEALTHCHECK --interval=30s \
+            --timeout=5s \
+            --start-period=10s \
+            --retries=3 \
+            CMD [ "/usr/bin/curl", "--silent", "--fail", "http://127.0.0.1:3000/" ]
+
 EXPOSE 3000
 
 CMD yarn prisma migrate deploy && yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,13 @@ COPY ./package.json ./yarn.lock ./playwright.config.ts ./
 
 RUN --mount=type=cache,sharing=locked,target=/usr/local/share/.cache/yarn \
     set -eux && \
-    yarn install --network-timeout 10000000
+    yarn install --network-timeout 10000000 && \
+    # Install curl for healthcheck
+    apt-get update && \
+    apt-get install -yqq --no-install-recommends curl && \
+    apt-get autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the compiled monolith binary from the builder stage
 COPY --from=monolith-builder /usr/local/cargo/bin/monolith /usr/local/bin/monolith


### PR DESCRIPTION
Updated the docker image with a HEALTHCHECK directive to avoid the need for users to specify one themselves in a docker-compose.yml (for example).

Used some typical values for the check, happy to tweak if necessary.

Also added the **curl** package (removed in https://github.com/linkwarden/linkwarden/commit/d60200205aa41f10930c932e247fb46e7547ccf6, but needed for the healthcheck to be executed).