### PR TITLE
fix(monolith): quote url

### DIFF
--- a/lib/api/preservationScheme/handleMonolith.ts
+++ b/lib/api/preservationScheme/handleMonolith.ts
@@ -8,7 +8,7 @@ const handleMonolith = async (link: Link, content: string) => {
 
   try {
     let html = execSync(
-      `monolith - -I -b ${link.url} ${
+      `monolith - -I -b "${link.url}" ${
         process.env.MONOLITH_CUSTOM_OPTIONS || "-j -F -s"
       } -o -`,
       {


### PR DESCRIPTION
when url include ampersand shell fails
```
/bin/sh: 1: amp: not found
/bin/sh: 1: -j: not found
Uncaught Monolith error...
```

Expected result:
```
Processing link http://www.youtube.com/watch?v=e5bALLcEygc&amp;feature=youtube_gdata_player for user 4
Succeeded processing link http://www.youtube.com/watch?v=e5bALLcEygc&amp;feature=youtube_gdata_player for user 4.
```

Actual result:
```
linkwarden-1  | [1] /bin/sh: 1: amp: not found
linkwarden-1  | [1] /bin/sh: 1: -j: not found
linkwarden-1  | [1] Uncaught Monolith error...
```