### PR TITLE
fix(import): save pinnedLinks from Linkwarden export json

### DIFF
--- a/lib/api/controllers/migration/importFromLinkwarden.ts
+++ b/lib/api/controllers/migration/importFromLinkwarden.ts
@@ -61,7 +61,7 @@ export default async function importFromLinkwarden(
               }
             }
 
-            await prisma.link.create({
+            const newLink = await prisma.link.create({
               data: {
                 url: link.url?.trim().slice(0, 254),
                 name: link.name?.trim().slice(0, 254),
@@ -97,6 +97,19 @@ export default async function importFromLinkwarden(
                   })),
                 },
               },
+            });
+            // Import pinnedLinks
+            data?.pinnedLinks.forEach(async (pinnedLink) => {
+              if (pinnedLink.url === newLink.url) {
+                await prisma.link.update({
+                  where: {
+                    id: newLink.id,
+                  },
+                  data: {
+                    pinnedBy: { connect: { id: userId } },
+                  },
+                });
+              }
             });
           }
         }

--- a/types/global.ts
+++ b/types/global.ts
@@ -108,6 +108,7 @@ interface CollectionIncludingLinks extends Collection {
 
 export interface Backup extends Omit<User, "password" | "id"> {
   collections: CollectionIncludingLinks[];
+  pinnedLinks: LinksIncludingTags[];
 }
 
 export type MigrationRequest = {


### PR DESCRIPTION
Pin newly imported links if backup.json pinnedLinks has it.

Tested to successfully pinned on my local installation.
Performance might be low if pinnedLinks are numerous. Improvements needed.