### PR TITLE
[Fix] Work around parser bug that mangles attribute values

### DIFF
--- a/lib/api/controllers/migration/importFromHTMLFile.ts
+++ b/lib/api/controllers/migration/importFromHTMLFile.ts
@@ -81,9 +81,9 @@ async function processBookmarks(
       } else if (item.type === "element" && item.tagName === "a") {
         // process link
 
-        const linkUrl = item?.attributes.find(
-          (e) => e.key.toLowerCase() === "href"
-        )?.value;
+        const linkUrl = item?.attributes
+          .find((e) => e.key.toLowerCase() === "href")
+          ?.value.replace(/&amp;/g, "&"); // Replace "&amp;" with "&" to get around parser bug
         const linkName = (
           item?.children.find((e) => e.type === "text") as TextNode
         )?.content;

--- a/lib/api/controllers/migration/importFromHTMLFile.ts
+++ b/lib/api/controllers/migration/importFromHTMLFile.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/api/db";
 import createFolder from "@/lib/api/storage/createFolder";
 import { JSDOM } from "jsdom";
+import { decodeHTML, DecodingMode } from "entities";
 import { parse, Node, Element, TextNode } from "himalaya";
 import { hasPassedLimit } from "../../verifyCapacity";
 
@@ -33,7 +34,6 @@ export default async function importFromHTMLFile(
   const processedArray = processNodes(jsonData);
 
   for (const item of processedArray) {
-    console.log(item);
     await processBookmarks(userId, item as Element);
   }
 
@@ -81,15 +81,17 @@ async function processBookmarks(
       } else if (item.type === "element" && item.tagName === "a") {
         // process link
 
-        const linkUrl = item?.attributes
-          .find((e) => e.key.toLowerCase() === "href")
-          ?.value.replace(/&amp;/g, "&"); // Replace "&amp;" with "&" to get around parser bug
+        const rawLinkUrl = item?.attributes.find(
+          (e) => e.key.toLowerCase() === "href"
+        )?.value;
+        const linkUrl = decodeEntities(rawLinkUrl);
         const linkName = (
           item?.children.find((e) => e.type === "text") as TextNode
         )?.content;
         const linkTags = item?.attributes
           .find((e) => e.key === "tags")
-          ?.value.split(",");
+          ?.value.split(",")
+          .map(decodeEntities);
 
         // set date if available
         const linkDateValue = item?.attributes.find(
@@ -289,4 +291,8 @@ function processNodes(nodes: Node[]) {
 
   nodes.forEach(findAndProcessDL);
   return nodes;
+}
+
+function decodeEntities(encoded: string | undefined): string {
+  return decodeHTML(encoded ?? "", DecodingMode.Attribute);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,9 +2556,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
-  version "1.0.30001502"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz#f7e4a76eb1d2d585340f773767be1fefc118dca8"
-  integrity sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==
+  version "1.0.30001690"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz"
+  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Addresses #557

It seems `jsdom` rewrites some attributes such that certain characters are replaced with [HTML Entities](https://developer.mozilla.org/en-US/docs/Glossary/Character_reference). For example, a URL bookmarked at `https://example.com/foo&bar=baz` parses as `https://example.com/foo&amp;bar=baz` (note the `&amp;`, which is not the same URL). Other attributes with URLs in them are also read incorrectly, but the user-facing issue is with `HREF` attributes.

This PR uses the same HTML entity encoder (the `entities` package) to decode JSDom's output correctly for both link URLs and link tags.