### PR TITLE
Update LinkCardCompact component to allow long link names to break on…

### DIFF
--- a/components/LinkViews/LinkComponents/LinkList.tsx
+++ b/components/LinkViews/LinkComponents/LinkList.tsx
@@ -129,7 +129,7 @@ export default function LinkCardCompact({ link, editMode }: Props) {
           <div className="w-[calc(100%-56px)] ml-2">
             {show.name && (
               <div className="flex gap-1 mr-20">
-                <p className="truncate text-primary">
+                <p className="text-primary break-words">
                   {unescapeString(link.name)}
                 </p>
                 {show.preserved_formats &&


### PR DESCRIPTION
## change-files
- LinkList.tsx

## features-add
allow long names to break on LinkView

## before
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/f552f233-5c63-4c48-a6a4-53eaf622211e" />

## after
<img width="1655" alt="image" src="https://github.com/user-attachments/assets/af69bfd8-d3e8-4d80-a624-e6687c815e77" />
