### PR TITLE
Add collection select sorting, fix inconsistent sidebar reorder

### DIFF
--- a/components/CollectionListing.tsx
+++ b/components/CollectionListing.tsx
@@ -112,6 +112,67 @@ const CollectionListing = () => {
     );
   };
 
+  function reorderTreeItems(tree, movedCollectionId, source, destination) {
+    // Same parent reordering
+    if (source.parentId === destination.parentId) {
+      const parent = tree.items[source.parentId];
+      const children = [...parent.children];
+
+      // Remove from source index
+      children.splice(source.index, 1);
+      // Insert at destination index
+      children.splice(destination.index, 0, movedCollectionId);
+
+      parent.children = children;
+      return tree;
+    }
+
+    // Different parent move
+    const sourceParent = tree.items[source.parentId];
+    const destinationParent = tree.items[destination.parentId];
+
+    // Remove from source parent
+    sourceParent.children = sourceParent.children.filter(id => id !== movedCollectionId);
+
+    // Initialize children array if it doesn't exist
+    if (!destinationParent.children) {
+      destinationParent.children = [];
+    }
+
+    // If destination index is not specified, add to the end
+    const destinationIndex = destination.index !== undefined ?
+      destination.index :
+      destinationParent.children.length;
+
+    // Add to destination parent
+    destinationParent.children.splice(destinationIndex, 0, movedCollectionId);
+
+    // Update destination parent properties
+    destinationParent.hasChildren = true;
+    destinationParent.isExpanded = true;
+
+    // Update the moved item's parent ID
+    tree.items[movedCollectionId].data.parentId = destination.parentId;
+
+    return tree;
+  }
+
+  function flattenTreeIds(tree, nodeId = 'root', result = []) {
+    const node = tree.items[nodeId];
+
+    if (nodeId !== 'root') {
+      result.push(node.id);
+    }
+
+    if (node.children && node.children.length > 0) {
+      node.children.forEach(childId => {
+        flattenTreeIds(tree, childId, result);
+      });
+    }
+
+    return result;
+  }
+
   const onDragEnd = async (
     source: TreeSourcePosition,
     destination: TreeDestinationPosition | undefined
@@ -148,7 +209,7 @@ const CollectionListing = () => {
 
     setTree((currentTree) => moveItemOnTree(currentTree!, source, destination));
 
-    const updatedCollectionOrder = [...user.collectionOrder];
+    const newTree = reorderTreeItems(tree, movedCollectionId, source, destination);
 
     if (source.parentId !== destination.parentId) {
       await updateCollection.mutateAsync(
@@ -169,42 +230,10 @@ const CollectionListing = () => {
       );
     }
 
-    if (
-      destination.index !== undefined &&
-      destination.parentId === source.parentId &&
-      source.parentId === "root"
-    ) {
-      updatedCollectionOrder.includes(movedCollectionId) &&
-        updatedCollectionOrder.splice(source.index, 1);
-
-      updatedCollectionOrder.splice(destination.index, 0, movedCollectionId);
-
-      await updateUser.mutateAsync({
-        ...user,
-        collectionOrder: updatedCollectionOrder,
-      });
-    } else if (
-      destination.index !== undefined &&
-      destination.parentId === "root"
-    ) {
-      updatedCollectionOrder.splice(destination.index, 0, movedCollectionId);
-
-      updateUser.mutate({
-        ...user,
-        collectionOrder: updatedCollectionOrder,
-      });
-    } else if (
-      source.parentId === "root" &&
-      destination.parentId &&
-      destination.parentId !== "root"
-    ) {
-      updatedCollectionOrder.splice(source.index, 1);
-
-      await updateUser.mutateAsync({
-        ...user,
-        collectionOrder: updatedCollectionOrder,
-      });
-    }
+    await updateUser.mutateAsync({
+      ...user,
+      collectionOrder: flattenTreeIds(newTree),
+    });
   };
 
   if (isLoading) {

--- a/components/CollectionListing.tsx
+++ b/components/CollectionListing.tsx
@@ -112,7 +112,12 @@ const CollectionListing = () => {
     );
   };
 
-  function reorderTreeItems(tree, movedCollectionId, source, destination) {
+  function reorderTreeItems(
+    tree: TreeData,
+    movedCollectionId: ItemId,
+    source: TreeSourcePosition,
+    destination: TreeDestinationPosition
+  ) {
     // Same parent reordering
     if (source.parentId === destination.parentId) {
       const parent = tree.items[source.parentId];
@@ -121,7 +126,9 @@ const CollectionListing = () => {
       // Remove from source index
       children.splice(source.index, 1);
       // Insert at destination index
-      children.splice(destination.index, 0, movedCollectionId);
+      if (destination.index) {
+        children.splice(destination.index, 0, movedCollectionId);
+      }
 
       parent.children = children;
       return tree;
@@ -132,7 +139,9 @@ const CollectionListing = () => {
     const destinationParent = tree.items[destination.parentId];
 
     // Remove from source parent
-    sourceParent.children = sourceParent.children.filter(id => id !== movedCollectionId);
+    sourceParent.children = sourceParent.children.filter(
+      (id) => id !== movedCollectionId
+    );
 
     // Initialize children array if it doesn't exist
     if (!destinationParent.children) {
@@ -140,9 +149,10 @@ const CollectionListing = () => {
     }
 
     // If destination index is not specified, add to the end
-    const destinationIndex = destination.index !== undefined ?
-      destination.index :
-      destinationParent.children.length;
+    const destinationIndex =
+      destination.index !== undefined
+        ? destination.index
+        : destinationParent.children.length;
 
     // Add to destination parent
     destinationParent.children.splice(destinationIndex, 0, movedCollectionId);
@@ -157,7 +167,7 @@ const CollectionListing = () => {
     return tree;
   }
 
-  function flattenTreeIds(tree, nodeId = 'root', result = []) {
+  function flattenTreeIds(tree: TreeData, nodeId: ItemId = 'root', result: Array<ItemId> = []) {
     const node = tree.items[nodeId];
 
     if (nodeId !== 'root') {

--- a/components/InputSelect/CollectionSelection.tsx
+++ b/components/InputSelect/CollectionSelection.tsx
@@ -50,20 +50,6 @@ export default function CollectionSelection({
     };
   }
 
-  useEffect(() => {
-    const formatedCollections = collections.map((e) => {
-      return {
-        value: e.id,
-        label: e.name,
-        ownerId: e.ownerId,
-        count: e._count,
-        parentId: e.parentId,
-      };
-    });
-
-    setOptions(formatedCollections);
-  }, [collections]);
-
   const getParentNames = (parentId: number): string[] => {
     const parentNames = [];
     const parent = collections.find((e) => e.id === parentId);
@@ -79,6 +65,24 @@ export default function CollectionSelection({
     return parentNames.reverse();
   };
 
+  useEffect(() => {
+    const formatedCollections = collections.map((e) => {
+      return {
+        value: e.id,
+        label: e.name,
+        parentsLabel: ((e.parentId && getParentNames(e.parentId).join(" > ") + " > ") || "") + e.name,
+        ownerId: e.ownerId,
+        count: e._count,
+        parentId: e.parentId,
+      };
+    })
+      .sort((a, b) => {
+        return a.parentsLabel.localeCompare(b.parentsLabel);
+      });
+
+    setOptions(formatedCollections);
+  }, [collections]);
+
   const customOption = ({ data, innerProps }: any) => {
     return (
       <div
@@ -90,13 +94,7 @@ export default function CollectionSelection({
           <span className="text-sm text-neutral">{data.count?.links}</span>
         </div>
         <div className="text-xs text-gray-600 dark:text-gray-300">
-          {getParentNames(data?.parentId).length > 0 ? (
-            <>
-              {getParentNames(data.parentId).join(" > ")} {">"} {data.label}
-            </>
-          ) : (
-            data.label
-          )}
+          {data.parentsLabel}
         </div>
       </div>
     );


### PR DESCRIPTION
Sometimes sidebar reordering doesn't work:
- collections are not saved within same parent
- collections moved to another parent are not saving positions on dragEnd, moving to the end of new parent instead

Also, fixed colleciton sorting in "Add new link", now it's sorted by parents first, then children - alphabetically