### PR TITLE
Fix collection card link count title

### DIFF
--- a/components/CollectionCard.tsx
+++ b/components/CollectionCard.tsx
@@ -185,7 +185,7 @@ export default function CollectionCard({
                 )}
                 <i
                   className="bi-link-45deg text-lg text-neutral"
-                  title={t("collection_publicly_shared")}
+                  title={t("links")}
                 ></i>
                 {collection._count && collection._count.links}
               </div>


### PR DESCRIPTION
The link icon on the collection card has a wrong title which is even misleading if the collection is NOT shared publicly.

This was originally introduced in cf1306d2c436e3f6de3d1a1cdb3bd6f0f64f09b1 and seemingly never noticed.

cc @saschaludwig