### PR TITLE
OpenRouter AI Provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -61,6 +61,10 @@ AZURE_MODEL=
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=
 
+# https://github.com/OpenRouterTeam/ai-sdk-provider
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=
+
 # MeiliSearch Settings
 MEILISEARCH_HOST=
 MEILISEARCH_KEY=

--- a/lib/api/archiveHandler.ts
+++ b/lib/api/archiveHandler.ts
@@ -49,7 +49,8 @@ export default async function archiveHandler(
           (process.env.NEXT_PUBLIC_OLLAMA_ENDPOINT_URL ||
             process.env.OPENAI_API_KEY ||
             process.env.AZURE_API_KEY ||
-            process.env.ANTHROPIC_API_KEY)
+            process.env.ANTHROPIC_API_KEY ||
+            process.env.OPENROUTER_API_KEY)
             ? true
             : undefined,
       },
@@ -148,7 +149,8 @@ export default async function archiveHandler(
             (process.env.NEXT_PUBLIC_OLLAMA_ENDPOINT_URL ||
               process.env.OPENAI_API_KEY ||
               process.env.AZURE_API_KEY ||
-              process.env.ANTHROPIC_API_KEY)
+              process.env.ANTHROPIC_API_KEY ||
+              process.env.OPENROUTER_API_KEY)
           )
             await autoTagLink(user, link.id, metaDescription);
 

--- a/lib/api/autoTagLink.ts
+++ b/lib/api/autoTagLink.ts
@@ -10,6 +10,7 @@ import { openai } from "@ai-sdk/openai";
 import { azure } from "@ai-sdk/azure";
 import { z } from "zod";
 import { anthropic } from "@ai-sdk/anthropic";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createOllama } from "ollama-ai-provider";
 import { titleCase } from "../shared/utils";
 
@@ -40,7 +41,13 @@ const getAIModel = (): LanguageModelV1 => {
       structuredOutputs: true,
     });
   }
+  if (process.env.OPENROUTER_API_KEY && process.env.OPENROUTER_MODEL) {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+    });
 
+    return openrouter(process.env.OPENROUTER_MODEL) as LanguageModelV1;
+  }
   throw new Error("No AI provider configured");
 };
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@aws-sdk/client-s3": "^3.379.1",
     "@headlessui/react": "^1.7.15",
     "@mozilla/readability": "^0.4.4",
+    "@openrouter/ai-sdk-provider": "^0.4.3",
     "@phosphor-icons/core": "^2.1.1",
     "@phosphor-icons/react": "^2.1.7",
     "@prisma/client": "^5.21.1",

--- a/pages/api/v1/config/index.ts
+++ b/pages/api/v1/config/index.ts
@@ -10,7 +10,8 @@ export const getEnvData = () => {
     process.env.NEXT_PUBLIC_OLLAMA_ENDPOINT_URL ||
     process.env.OPENAI_API_KEY ||
     process.env.AZURE_API_KEY ||
-    process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.OPENROUTER_API_KEY
   );
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,16 @@
     "@ai-sdk/provider" "1.0.6"
     "@ai-sdk/provider-utils" "2.1.5"
 
+"@ai-sdk/provider-utils@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz#dfd671ccda12e321b58f347b6cbbdd982d139359"
+  integrity sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==
+  dependencies:
+    "@ai-sdk/provider" "1.0.9"
+    eventsource-parser "^3.0.0"
+    nanoid "^3.3.8"
+    secure-json-parse "^2.7.0"
+
 "@ai-sdk/provider-utils@2.1.5", "@ai-sdk/provider-utils@^2.0.0":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.1.5.tgz#acceca29bef1ed3855789197c3b587e260f995d4"
@@ -46,6 +56,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.0.6.tgz#ab7e53a48a2cefe7bd593590a611b2ce12465bc3"
   integrity sha512-hwj/gFNxpDgEfTaYzCYoslmw01IY9kWLKl/wf8xuPvHtQIzlfXWmmUwc8PnCwxyt8cKzIuV0dfUghCf68HQ0SA==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.0.9.tgz#01c2e69df8258aed5b1fe08fba380133a645800f"
+  integrity sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==
   dependencies:
     json-schema "^0.4.0"
 
@@ -1329,6 +1346,14 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@openrouter/ai-sdk-provider@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@openrouter/ai-sdk-provider/-/ai-sdk-provider-0.4.3.tgz#2315165a0c15c48c10473a6b4e20487e91f24339"
+  integrity sha512-/MAUj5XFKs6IRZ3WwD8qFyUC6I+yhQ4TsemxvwDk+mbXNiVuJvP5Qc+yJ4fKTfIP4vRiV1sApA/t/La5MgA2FQ==
+  dependencies:
+    "@ai-sdk/provider" "1.0.9"
+    "@ai-sdk/provider-utils" "2.1.10"
 
 "@opentelemetry/api@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
Add OpenRouter Provider Support

- https://github.com/OpenRouterTeam/ai-sdk-provider
- https://sdk.vercel.ai/providers/community-providers/openrouter#openrouter

---

message:

I encountered type errors when using `getAIModel` with the OpenRouter provider.

To resolve this issue, I've implemented a workaround using type assertion:
```typescript
return openrouter(process.env.OPENROUTER_MODEL) as LanguageModelV1;
```

https://github.com/OpenRouterTeam/ai-sdk-provider/blob/ec35ab7a59816039c915b0a5d483ff6260fcf1d6/src/openrouter-completion-language-model.ts#L39

If there's a more elegant approach to handle this typing issue, I'd welcome suggestions for improvement.