### PR TITLE
(fix) MainLayout nested scrolling when ViewMode.List

### DIFF
--- a/layouts/MainLayout.tsx
+++ b/layouts/MainLayout.tsx
@@ -42,7 +42,7 @@ export default function MainLayout({ children }: Props) {
       </div>
 
       <div
-        className={`lg:w-[calc(100%-320px)] overflow-x-hidden w-full sm:pb-0 pb-20 flex flex-col min-h-screen lg:ml-80`}
+        className={`lg:w-[calc(100%-320px)] w-full sm:pb-0 pb-20 flex flex-col min-h-screen lg:ml-80`}
       >
         <Navbar />
         {children}


### PR DESCRIPTION
Hi, thanks for the awesome project! I just signed up and noticed some janky nested scrolling in the `/collections/...` view. I hope this PR is useful, feel free to modify/close as you see fit.

(I think) this commit aa0c7d6 introduced a bug where, when `ViewMode === List`, two (vertical) scrollbars appear - one nested inside the other and scrolling initially incorrectly scrolls the outer content before then scrolling the inner content.

afaict `overflow-x-hidden` is not needed (I can't see any horizontal scrollbars without it) and removing it fixes the issue.

There're certainly otherways to fix this, such as explicitly setting `overflow-y` to a value that doesn't cause a nested scroll, but if I'm right that `overflow-x-hidden` isn't needed then this solution also removes some unneeded complexity.

Also, I tried to use `https://demo.linkwarden.app/collections/...` to create a recording of the bug but it didn't contain the css from aa0c7d6 so I guess it's not deployed that frequently.


https://github.com/user-attachments/assets/0a536431-ad88-40fd-9df9-ed957087143e


