### PR TITLE
Fix Prisma schema path configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "apps/*",
     "packages/*"
   ],
+  "prisma": {
+    "schema": "packages/prisma/schema.prisma"
+  },
   "scripts": {
     "web:dev": "dotenv -- yarn workspace @linkwarden/web dev",
     "web:build": "dotenv -- yarn workspace @linkwarden/web build",


### PR DESCRIPTION
Error without this:
```
> npx prisma migrate dev
Environment variables loaded from .env
Error: Could not find Prisma Schema that is required for this command.
You can either provide it with `--schema` argument, set it as `prisma.schema` in your package.json or put it into the default location.
Checked following paths:

schema.prisma: file not found
prisma\schema.prisma: file not found
prisma\schema: directory not found

See also https://pris.ly/d/prisma-schema-location
```