### PR TITLE
fix: "Error copying file" when no src file

### DIFF
--- a/apps/web/lib/api/controllers/collections/postCollection.ts
+++ b/apps/web/lib/api/controllers/collections/postCollection.ts
@@ -96,6 +96,7 @@ export default async function postCollection(
   });
 
   createFolder({ filePath: `archives/${newCollection.id}` });
+  createFolder({ filePath: `archives/preview/${newCollection.id}` });
 
   return { response: newCollection, status: 200 };
 }

--- a/packages/filesystem/moveFile.ts
+++ b/packages/filesystem/moveFile.ts
@@ -30,8 +30,10 @@ export async function moveFile(from: string, to: string) {
     const directory = (file: string) =>
       path.join(process.cwd(), "../..", storagePath, file);
 
-    fs.rename(directory(from), directory(to), (err) => {
-      if (err) console.log("Error copying file:", err);
-    });
+    if (fs.existsSync(directory(from))) {
+      fs.rename(directory(from), directory(to), (err) => {
+        if (err) console.log("Error copying file:", err);
+      });
+    }
   }
 }


### PR DESCRIPTION
A small adjustment to avoid unnecessary error message during file operations 