### PR TITLE
fix(web): fix capitalization of collection names

### DIFF
--- a/apps/web/components/LinkViews/LinkComponents/LinkCollection.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkCollection.tsx
@@ -42,7 +42,7 @@ export default function LinkCollection({
             style={{ color: link.collection.color }}
           ></i>
         )}
-        <p className="truncate capitalize">{collection?.name}</p>
+        <p className="truncate">{collection?.name}</p>
       </Link>
     </>
   ) : null;

--- a/apps/web/components/ModalContent/NewCollectionModal.tsx
+++ b/apps/web/components/ModalContent/NewCollectionModal.tsx
@@ -63,7 +63,7 @@ export default function NewCollectionModal({ onClose, parent }: Props) {
       {parent?.id ? (
         <>
           <p className="text-xl font-thin">{t("new_sub_collection")}</p>
-          <p className="capitalize text-sm">
+          <p className="text-sm">
             {t("for_collection", { name: parent.name })}
           </p>
         </>

--- a/apps/web/pages/collections/[id].tsx
+++ b/apps/web/pages/collections/[id].tsx
@@ -130,7 +130,7 @@ export default function Index() {
                 ></i>
               )}
 
-              <p className="sm:text-3xl text-2xl capitalize w-full py-1 break-words hyphens-auto font-thin">
+              <p className="sm:text-3xl text-2xl w-full py-1 break-words hyphens-auto font-thin">
                 {activeCollection?.name}
               </p>
             </div>

--- a/apps/web/pages/public/collections/[id]/index.tsx
+++ b/apps/web/pages/public/collections/[id]/index.tsx
@@ -113,7 +113,7 @@ export default function PublicCollections() {
         <div className="lg:w-3/4 max-w-[1500px] w-full mx-auto p-5 bg">
           <div className="flex justify-between gap-2">
             <div className="w-full">
-              <p className="text-4xl font-thin mb-2 capitalize mt-10">
+              <p className="text-4xl font-thin mb-2 mt-10">
                 {collection.name}
               </p>
 


### PR DESCRIPTION
Fixes the auto-capitalization of collection names. This caused some instances of the collection name to appear capitalized, even if the actual collection name started with a lowercase letter.

This caused problems for names such as "macOS" and "iOS" as they instead sometimes appeared as "MacOS" and "IOS".

![Reproduction](https://github.com/user-attachments/assets/c95f4eb3-02ca-412d-831b-40fa020dd4da)