### PR TITLE
refactor(web): allow line breaks in link description in view mode

### DIFF
--- a/apps/web/components/LinkDetails.tsx
+++ b/apps/web/components/LinkDetails.tsx
@@ -472,7 +472,7 @@ export default function LinkDetails({
             {mode === "view" ? (
               <div className="rounded-md p-2 bg-base-200 hyphens-auto">
                 {link.description ? (
-                  <p>{link.description}</p>
+                  <p className="whitespace-pre-wrap">{link.description}</p>
                 ) : (
                   <p className="text-neutral">{t("no_description_provided")}</p>
                 )}


### PR DESCRIPTION
ref issue: https://github.com/linkwarden/linkwarden/issues/729

Allows the Description field to display line breaks and multiple spaces in view mode.

Before
![image](https://github.com/user-attachments/assets/3f717a68-e003-4641-b054-9e07e21cdd2c)

After
![image](https://github.com/user-attachments/assets/bed0ae9e-8f90-40f1-921a-49e2971267ff)