### PR TITLE
improve preview generation for webpages in case site does not provide an icon

### DIFF
--- a/apps/worker/lib/preservationScheme/handleArchivePreview.ts
+++ b/apps/worker/lib/preservationScheme/handleArchivePreview.ts
@@ -19,6 +19,8 @@ const handleArchivePreview = async (
     return metaTag ? (metaTag as any).content : null;
   });
 
+  let previewGenerated = false;
+
   if (ogImageUrl) {
     console.log("Found og:image URL:", ogImageUrl);
 
@@ -28,11 +30,13 @@ const handleArchivePreview = async (
     // Check if imageResponse is not null
     if (imageResponse && !link.preview?.startsWith("archive")) {
       const buffer = await imageResponse.body();
-      generatePreview(buffer, link.collectionId, link.id);
+      previewGenerated = generatePreview(buffer, link.collectionId, link.id);
     }
 
     await page.goBack();
-  } else if (!link.preview?.startsWith("archive")) {
+  }
+
+  if (!previewGenerated && !link.preview?.startsWith("archive")) {
     console.log("No og:image found");
     await page
       .screenshot({ type: "jpeg", quality: 20 })


### PR DESCRIPTION
Hi,

as mentioned in this post:

https://github.com/linkwarden/linkwarden/issues/1106

I have slightly optimized the preview generation for webpages by falling back to the screen capture logic in case there is no site preview available. For me the overview looks much better that way and it is easier to find what I am searching for. Maybe you can consider this for the main branch also.

Thanks!