### PR TITLE
Fix subscription check blocking user creation in admin dashboard

### DIFF
--- a/apps/web/lib/api/isAuthenticatedRequest.ts
+++ b/apps/web/lib/api/isAuthenticatedRequest.ts
@@ -2,6 +2,8 @@ import { NextApiRequest } from "next";
 import { getToken } from "next-auth/jwt";
 import { prisma } from "@linkwarden/prisma";
 
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+
 type Props = {
   req: NextApiRequest;
 };
@@ -39,7 +41,7 @@ export default async function isAuthenticatedRequest({ req }: Props) {
     },
   });
 
-  if (findUser && !findUser?.subscriptions) {
+  if (STRIPE_SECRET_KEY && findUser && !findUser?.subscriptions) {
     return null;
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue that prevents administrators from creating new users in self-hosted Linkwarden instances. The `isAuthenticatedRequest` function was checking for user subscriptions even when Stripe is not configured.

Related issue: https://github.com/linkwarden/linkwarden/issues/984
