### PR TITLE
feat: add drag and drop to move links between collection on dashboard page

### DIFF
--- a/apps/web/components/CollectionListing.tsx
+++ b/apps/web/components/CollectionListing.tsx
@@ -22,6 +22,7 @@ import {
 import { useUpdateUser, useUser } from "@linkwarden/router/user";
 import Icon from "./Icon";
 import { IconWeight } from "@phosphor-icons/react";
+import Droppable from "./Droppable";
 
 interface ExtendedTreeItem extends TreeItem {
   data: Collection;
@@ -295,54 +296,67 @@ const renderItem = (
   const collection = item.data;
 
   return (
-    <div ref={provided.innerRef} {...provided.draggableProps} className="mb-1">
+    <Droppable
+      id={`side-bar-collection-${collection.id}`}
+      data={{
+        collectionName: collection.name,
+        collectionId: collection.id,
+        ownerId: collection.ownerId,
+      }}
+    >
       <div
-        className={`${
-          currentPath === `/collections/${collection.id}`
-            ? "bg-primary/20 is-active"
-            : "hover:bg-neutral/20"
-        } duration-100 flex gap-1 items-center pr-2 pl-1 rounded-md`}
+        ref={provided.innerRef}
+        {...provided.draggableProps}
+        className="mb-1"
       >
-        {Dropdown(item as ExtendedTreeItem, onExpand, onCollapse)}
-
-        <Link
-          href={`/collections/${collection.id}`}
-          className="w-full"
-          {...provided.dragHandleProps}
+        <div
+          className={`${
+            currentPath === `/collections/${collection.id}`
+              ? "bg-primary/20 is-active"
+              : "hover:bg-neutral/20"
+          } duration-100 flex gap-1 items-center pr-2 pl-1 rounded-md`}
         >
-          <div
-            className={`py-1 cursor-pointer flex items-center gap-2 w-full rounded-md h-8`}
+          {Dropdown(item as ExtendedTreeItem, onExpand, onCollapse)}
+
+          <Link
+            href={`/collections/${collection.id}`}
+            className="w-full"
+            {...provided.dragHandleProps}
           >
-            {collection.icon ? (
-              <Icon
-                icon={collection.icon}
-                size={30}
-                weight={(collection.iconWeight || "regular") as IconWeight}
-                color={collection.color}
-                className="-mr-[0.15rem]"
-              />
-            ) : (
-              <i
-                className="bi-folder-fill text-xl"
-                style={{ color: collection.color }}
-              ></i>
-            )}
+            <div
+              className={`py-1 cursor-pointer flex items-center gap-2 w-full rounded-md h-8`}
+            >
+              {collection.icon ? (
+                <Icon
+                  icon={collection.icon}
+                  size={30}
+                  weight={(collection.iconWeight || "regular") as IconWeight}
+                  color={collection.color}
+                  className="-mr-[0.15rem]"
+                />
+              ) : (
+                <i
+                  className="bi-folder-fill text-xl"
+                  style={{ color: collection.color }}
+                ></i>
+              )}
 
-            <p className="truncate w-full">{collection.name}</p>
+              <p className="truncate w-full">{collection.name}</p>
 
-            {collection.isPublic && (
-              <i
-                className="bi-globe2 text-sm text-black/50 dark:text-white/50 drop-shadow"
-                title="This collection is being shared publicly."
-              ></i>
-            )}
-            <div className="drop-shadow text-neutral text-xs">
-              {collection._count?.links}
+              {collection.isPublic && (
+                <i
+                  className="bi-globe2 text-sm text-black/50 dark:text-white/50 drop-shadow"
+                  title="This collection is being shared publicly."
+                ></i>
+              )}
+              <div className="drop-shadow text-neutral text-xs">
+                {collection._count?.links}
+              </div>
             </div>
-          </div>
-        </Link>
+          </Link>
+        </div>
       </div>
-    </div>
+    </Droppable>
   );
 };
 

--- a/apps/web/components/CollectionListing.tsx
+++ b/apps/web/components/CollectionListing.tsx
@@ -300,8 +300,8 @@ const renderItem = (
     <Droppable
       id={`side-bar-collection-${collection.id}`}
       data={{
-        collectionName: collection.name,
-        collectionId: collection.id,
+        name: collection.name,
+        id: collection.id,
         ownerId: collection.ownerId,
       }}
       className="group"

--- a/apps/web/components/CollectionListing.tsx
+++ b/apps/web/components/CollectionListing.tsx
@@ -23,6 +23,7 @@ import { useUpdateUser, useUser } from "@linkwarden/router/user";
 import Icon from "./Icon";
 import { IconWeight } from "@phosphor-icons/react";
 import Droppable from "./Droppable";
+import { cn } from "@linkwarden/lib";
 
 interface ExtendedTreeItem extends TreeItem {
   data: Collection;
@@ -303,6 +304,7 @@ const renderItem = (
         collectionId: collection.id,
         ownerId: collection.ownerId,
       }}
+      className="group"
     >
       <div
         ref={provided.innerRef}
@@ -310,11 +312,12 @@ const renderItem = (
         className="mb-1"
       >
         <div
-          className={`${
+          className={cn(
             currentPath === `/collections/${collection.id}`
               ? "bg-primary/20 is-active"
-              : "hover:bg-neutral/20"
-          } duration-100 flex gap-1 items-center pr-2 pl-1 rounded-md`}
+              : "group-[&:not([data-over])]:hover:bg-neutral/20",
+            "duration-100 flex gap-1 items-center pr-2 pl-1 rounded-md"
+          )}
         >
           {Dropdown(item as ExtendedTreeItem, onExpand, onCollapse)}
 

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -150,11 +150,10 @@ export function Card({ link, editMode, dashboardType }: Props) {
       <span
         {...listeners}
         {...attributes}
-        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-6 h-6 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center"
+        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-8 h-8 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center touch-none"
         title="Drag to reorder"
       >
-        {/* <GripIcon className="h-4 w-4" /> */}
-        <i className="bi-grip-vertical" />
+        <i className="bi-grip-vertical text-xl" />
       </span>
       <div
         ref={ref}

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -27,7 +27,6 @@ import LinkPin from "./LinkViews/LinkComponents/LinkPin";
 import { Separator } from "./ui/separator";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@linkwarden/lib";
-import { GripIcon } from "lucide-react";
 
 export function DashboardLinks({
   links,
@@ -69,6 +68,7 @@ export function Card({ link, editMode, dashboardType }: Props) {
     id: `${link.id}-${dashboardType}`,
     data: {
       linkId: link.id,
+      dashboardType,
     },
   });
   const { data: collections = [] } = useCollections();

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -27,7 +27,6 @@ import LinkPin from "./LinkViews/LinkComponents/LinkPin";
 import { Separator } from "./ui/separator";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@linkwarden/lib";
-import { Button } from "./ui/button";
 import { GripIcon } from "lucide-react";
 
 export function DashboardLinks({
@@ -142,9 +141,21 @@ export function Card({ link, editMode, dashboardType }: Props) {
   return (
     <div
       ref={setNodeRef}
-      className={cn(isDragging ? "opacity-30" : "opacity-100")}
+      className={cn(
+        isDragging ? "opacity-30" : "opacity-100",
+        "relative group"
+      )}
       id={`${link.id}-${dashboardType}`}
     >
+      <span
+        {...listeners}
+        {...attributes}
+        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-6 h-6 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center"
+        title="Drag to reorder"
+      >
+        {/* <GripIcon className="h-4 w-4" /> */}
+        <i className="bi-grip-vertical" />
+      </span>
       <div
         ref={ref}
         className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group`}
@@ -158,15 +169,6 @@ export function Card({ link, editMode, dashboardType }: Props) {
           {show.image && (
             <div>
               <div className={`relative rounded-t-xl h-40 overflow-hidden`}>
-                <Button
-                  size="icon"
-                  className="absolute z-50 opacity-0 top-2 left-2 group-hover:opacity-100"
-                  variant="ghost"
-                  {...listeners}
-                  {...attributes}
-                >
-                  <GripIcon />
-                </Button>
                 {formatAvailable(link, "preview") ? (
                   <Image
                     src={`/api/v1/archives/${link.id}?format=${ArchivedFormat.jpeg}&preview=true&updatedAt=${link.updatedAt}`}

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -65,6 +65,7 @@ type Props = {
 };
 
 export function Card({ link, editMode, dashboardType }: Props) {
+  const [linkDropdownMenuOpen, setLinkDropdownMenuOpen] = useState(false);
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `${link.id}-${dashboardType}`,
     data: {
@@ -239,7 +240,12 @@ export function Card({ link, editMode, dashboardType }: Props) {
           collection={collection}
           linkModal={linkModal}
           setLinkModal={(e) => setLinkModal(e)}
-          className="absolute top-3 right-3 group-hover:opacity-100 opacity-0 duration-100 text-neutral z-20"
+          onLinkDropdownMenuOpen={(e) => setLinkDropdownMenuOpen(e)}
+          dropdownMenuOpen={linkDropdownMenuOpen}
+          className={cn(
+            "absolute top-3 right-3 group-hover:opacity-100 opacity-0 duration-100 text-neutral z-20",
+            linkDropdownMenuOpen && "opacity-100"
+          )}
         />
         {!isPublicRoute && <LinkPin link={link} />}
       </div>

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -79,7 +79,6 @@ type Props = {
 };
 
 export function Card({ link, editMode, dashboardType }: Props) {
-  const [linkDropdownMenuOpen, setLinkDropdownMenuOpen] = useState(false);
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `${link.id}-${dashboardType}`,
     data: {
@@ -256,12 +255,7 @@ export function Card({ link, editMode, dashboardType }: Props) {
           collection={collection}
           linkModal={linkModal}
           setLinkModal={(e) => setLinkModal(e)}
-          onLinkDropdownMenuOpen={(e) => setLinkDropdownMenuOpen(e)}
-          dropdownMenuOpen={linkDropdownMenuOpen}
-          className={cn(
-            "absolute top-3 right-3 group-hover:opacity-100 opacity-0 duration-100 text-neutral z-20",
-            linkDropdownMenuOpen && "opacity-100"
-          )}
+          className="absolute top-3 right-3 group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral z-20"
         />
         {!isPublicRoute && <LinkPin link={link} />}
       </div>

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -171,7 +171,7 @@ export function Card({ link, editMode, dashboardType }: Props) {
       </span>
       <div
         ref={ref}
-        className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group`}
+        className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group h-full`}
       >
         <div
           className="rounded-xl cursor-pointer h-full w-full flex flex-col justify-between"

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -159,14 +159,13 @@ export function Card({ link, editMode, dashboardType }: Props) {
       ref={setNodeRef}
       className={cn(
         isDragging ? "opacity-30" : "opacity-100",
-        "relative group"
+        "relative group touch-manipulation select-none"
       )}
-      id={`${link.id}-${dashboardType}`}
+      {...listeners}
+      {...attributes}
     >
       <span
-        {...listeners}
-        {...attributes}
-        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-8 h-8 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center touch-none"
+        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-8 h-8 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center"
         title="Drag to reorder"
       >
         <i className="bi-grip-vertical text-xl" />

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -147,12 +147,6 @@ export function Card({ link, editMode, dashboardType }: Props) {
       {...listeners}
       {...attributes}
     >
-      <span
-        className="absolute z-50 opacity-0 top-3 left-2 group-hover:opacity-60 w-8 h-8 transition-opacity duration-200 cursor-grab  p-1 rounded bg-base-100/80 group-hover:hover:opacity-100 inline-flex items-center justify-center"
-        title="Drag to reorder"
-      >
-        <i className="bi-grip-vertical text-xl" />
-      </span>
       <div
         ref={ref}
         className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group h-full`}

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -28,27 +28,14 @@ import { Separator } from "./ui/separator";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@linkwarden/lib";
 
-const PlaceholderCard = () => {
-  return (
-    <div className="w-60 border-2 border-dashed border-neutral-content bg-base/80 rounded-xl flex items-center justify-center h-72">
-      <div className="flex flex-col items-center gap-2 text-primary/70">
-        <i className="bi-plus-circle text-4xl"></i>
-        <p className="text-sm font-medium">Drop link here</p>
-      </div>
-    </div>
-  );
-};
-
 export function DashboardLinks({
   links,
   isLoading,
   type,
-  isDropping,
 }: {
   links?: LinkIncludingShortenedCollectionAndTags[];
   isLoading?: boolean;
   type?: "collection" | "recent";
-  isDropping?: boolean;
 }) {
   return (
     <div
@@ -63,10 +50,7 @@ export function DashboardLinks({
           <div className="skeleton h-3 w-1/3"></div>
         </div>
       ) : (
-        <>
-          {links?.map((e, i) => <Card key={i} link={e} dashboardType={type} />)}
-          {isDropping && <PlaceholderCard />}
-        </>
+        links?.map((e, i) => <Card key={i} link={e} dashboardType={type} />)
       )}
     </div>
   );

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -28,14 +28,27 @@ import { Separator } from "./ui/separator";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@linkwarden/lib";
 
+const PlaceholderCard = () => {
+  return (
+    <div className="w-60 border-2 border-dashed border-neutral-content bg-base/80 rounded-xl flex items-center justify-center h-72">
+      <div className="flex flex-col items-center gap-2 text-primary/70">
+        <i className="bi-plus-circle text-4xl"></i>
+        <p className="text-sm font-medium">Drop link here</p>
+      </div>
+    </div>
+  );
+};
+
 export function DashboardLinks({
   links,
   isLoading,
   type,
+  isDropping,
 }: {
   links?: LinkIncludingShortenedCollectionAndTags[];
   isLoading?: boolean;
   type?: "collection" | "recent";
+  isDropping?: boolean;
 }) {
   return (
     <div
@@ -50,7 +63,10 @@ export function DashboardLinks({
           <div className="skeleton h-3 w-1/3"></div>
         </div>
       ) : (
-        links?.map((e, i) => <Card key={i} link={e} dashboardType={type} />)
+        <>
+          {links?.map((e, i) => <Card key={i} link={e} dashboardType={type} />)}
+          {isDropping && <PlaceholderCard />}
+        </>
       )}
     </div>
   );

--- a/apps/web/components/DashboardLinks.tsx
+++ b/apps/web/components/DashboardLinks.tsx
@@ -25,13 +25,19 @@ import LinkFormats from "./LinkViews/LinkComponents/LinkFormats";
 import LinkTypeBadge from "./LinkViews/LinkComponents/LinkTypeBadge";
 import LinkPin from "./LinkViews/LinkComponents/LinkPin";
 import { Separator } from "./ui/separator";
+import { useDraggable } from "@dnd-kit/core";
+import { cn } from "@linkwarden/lib";
+import { Button } from "./ui/button";
+import { GripIcon } from "lucide-react";
 
 export function DashboardLinks({
   links,
   isLoading,
+  type,
 }: {
   links?: LinkIncludingShortenedCollectionAndTags[];
   isLoading?: boolean;
+  type?: "collection" | "recent";
 }) {
   return (
     <div
@@ -46,7 +52,7 @@ export function DashboardLinks({
           <div className="skeleton h-3 w-1/3"></div>
         </div>
       ) : (
-        links?.map((e, i) => <Card key={i} link={e} />)
+        links?.map((e, i) => <Card key={i} link={e} dashboardType={type} />)
       )}
     </div>
   );
@@ -55,9 +61,16 @@ export function DashboardLinks({
 type Props = {
   link: LinkIncludingShortenedCollectionAndTags;
   editMode?: boolean;
+  dashboardType?: "collection" | "recent";
 };
 
-export function Card({ link, editMode }: Props) {
+export function Card({ link, editMode, dashboardType }: Props) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `${link.id}-${dashboardType}`,
+    data: {
+      linkId: link.id,
+    },
+  });
   const { data: collections = [] } = useCollections();
 
   const { data: user } = useUser();
@@ -127,94 +140,109 @@ export function Card({ link, editMode }: Props) {
 
   return (
     <div
-      ref={ref}
-      className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group`}
+      ref={setNodeRef}
+      className={cn(isDragging ? "opacity-30" : "opacity-100")}
+      id={`${link.id}-${dashboardType}`}
     >
       <div
-        className="rounded-xl cursor-pointer h-full w-full flex flex-col justify-between"
-        onClick={() =>
-          !editMode && openLink(link, user, () => setLinkModal(true))
-        }
+        ref={ref}
+        className={`min-w-60 w-60 border border-solid border-neutral-content bg-base-200 duration-100 rounded-xl relative group`}
       >
-        {show.image && (
-          <div>
-            <div className={`relative rounded-t-xl h-40 overflow-hidden`}>
-              {formatAvailable(link, "preview") ? (
-                <Image
-                  src={`/api/v1/archives/${link.id}?format=${ArchivedFormat.jpeg}&preview=true&updatedAt=${link.updatedAt}`}
-                  width={1280}
-                  height={720}
-                  alt=""
-                  className={`rounded-t-xl select-none object-cover z-10 h-40 w-full shadow opacity-80 scale-105`}
-                  style={show.icon ? { filter: "blur(1px)" } : undefined}
-                  draggable="false"
-                  onError={(e) => {
-                    const target = e.target as HTMLElement;
-                    target.style.display = "none";
-                  }}
-                />
-              ) : link.preview === "unavailable" ? (
-                <div className={`bg-gray-50 h-40 bg-opacity-80`}></div>
-              ) : (
-                <div
-                  className={`h-40 bg-opacity-80 skeleton rounded-none`}
-                ></div>
-              )}
-              {show.icon && (
-                <div className="absolute top-0 left-0 right-0 bottom-0 rounded-t-xl flex items-center justify-center rounded-md">
-                  <LinkIcon link={link} />
-                </div>
-              )}
-              {show.preserved_formats &&
-                link.type === "url" &&
-                atLeastOneFormatAvailable(link) && (
-                  <div className="absolute bottom-0 right-0 m-2 bg-base-200 bg-opacity-60 px-1 rounded-md">
-                    <LinkFormats link={link} />
-                  </div>
-                )}
-            </div>
-            <Separator />
-          </div>
-        )}
-
-        <div className="flex flex-col justify-between h-full min-h-24">
-          <div className="p-3 flex flex-col justify-between h-full gap-2">
-            {show.name && (
-              <p className="line-clamp-2 w-full text-primary text-sm">
-                {unescapeString(link.name)}
-              </p>
-            )}
-
-            {show.link && <LinkTypeBadge link={link} />}
-          </div>
-
-          {(show.collection || show.date) && (
+        <div
+          className="rounded-xl cursor-pointer h-full w-full flex flex-col justify-between"
+          onClick={() =>
+            !editMode && openLink(link, user, () => setLinkModal(true))
+          }
+        >
+          {show.image && (
             <div>
-              <Separator className="mb-1" />
-
-              <div className="flex justify-between items-center text-xs text-neutral px-3 pb-1 gap-2">
-                {show.collection && !isPublicRoute && (
-                  <div className="cursor-pointer truncate">
-                    <LinkCollection link={link} collection={collection} />
+              <div className={`relative rounded-t-xl h-40 overflow-hidden`}>
+                <Button
+                  size="icon"
+                  className="absolute z-50 opacity-0 top-2 left-2 group-hover:opacity-100"
+                  variant="ghost"
+                  {...listeners}
+                  {...attributes}
+                >
+                  <GripIcon />
+                </Button>
+                {formatAvailable(link, "preview") ? (
+                  <Image
+                    src={`/api/v1/archives/${link.id}?format=${ArchivedFormat.jpeg}&preview=true&updatedAt=${link.updatedAt}`}
+                    width={1280}
+                    height={720}
+                    alt=""
+                    className={`rounded-t-xl select-none object-cover z-10 h-40 w-full shadow opacity-80 scale-105`}
+                    style={show.icon ? { filter: "blur(1px)" } : undefined}
+                    draggable="false"
+                    onError={(e) => {
+                      const target = e.target as HTMLElement;
+                      target.style.display = "none";
+                    }}
+                  />
+                ) : link.preview === "unavailable" ? (
+                  <div className={`bg-gray-50 h-40 bg-opacity-80`}></div>
+                ) : (
+                  <div
+                    className={`h-40 bg-opacity-80 skeleton rounded-none`}
+                  ></div>
+                )}
+                {show.icon && (
+                  <div className="absolute top-0 left-0 right-0 bottom-0 rounded-t-xl flex items-center justify-center rounded-md">
+                    <LinkIcon link={link} />
                   </div>
                 )}
-                {show.date && <LinkDate link={link} />}
+                {show.preserved_formats &&
+                  link.type === "url" &&
+                  atLeastOneFormatAvailable(link) && (
+                    <div className="absolute bottom-0 right-0 m-2 bg-base-200 bg-opacity-60 px-1 rounded-md">
+                      <LinkFormats link={link} />
+                    </div>
+                  )}
               </div>
+              <Separator />
             </div>
           )}
-        </div>
-      </div>
 
-      {/* Overlay on hover */}
-      <div className="absolute pointer-events-none top-0 left-0 right-0 bottom-0 bg-base-100 bg-opacity-0 group-hover:bg-opacity-20 group-focus-within:opacity-20 rounded-xl duration-100"></div>
-      <LinkActions
-        link={link}
-        collection={collection}
-        linkModal={linkModal}
-        setLinkModal={(e) => setLinkModal(e)}
-        className="absolute top-3 right-3 group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral z-20"
-      />
-      {!isPublicRoute && <LinkPin link={link} />}
+          <div className="flex flex-col justify-between h-full min-h-24">
+            <div className="p-3 flex flex-col justify-between h-full gap-2">
+              {show.name && (
+                <p className="line-clamp-2 w-full text-primary text-sm">
+                  {unescapeString(link.name)}
+                </p>
+              )}
+
+              {show.link && <LinkTypeBadge link={link} />}
+            </div>
+
+            {(show.collection || show.date) && (
+              <div>
+                <Separator className="mb-1" />
+
+                <div className="flex justify-between items-center text-xs text-neutral px-3 pb-1 gap-2">
+                  {show.collection && !isPublicRoute && (
+                    <div className="cursor-pointer truncate">
+                      <LinkCollection link={link} collection={collection} />
+                    </div>
+                  )}
+                  {show.date && <LinkDate link={link} />}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Overlay on hover */}
+        <div className="absolute pointer-events-none top-0 left-0 right-0 bottom-0 bg-base-100 bg-opacity-0 group-hover:bg-opacity-20 group-focus-within:opacity-20 rounded-xl duration-100"></div>
+        <LinkActions
+          link={link}
+          collection={collection}
+          linkModal={linkModal}
+          setLinkModal={(e) => setLinkModal(e)}
+          className="absolute top-3 right-3 group-hover:opacity-100 opacity-0 duration-100 text-neutral z-20"
+        />
+        {!isPublicRoute && <LinkPin link={link} />}
+      </div>
     </div>
   );
 }

--- a/apps/web/components/DragNDrop.tsx
+++ b/apps/web/components/DragNDrop.tsx
@@ -1,0 +1,151 @@
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  SensorDescriptor,
+  SensorOptions,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import LinkIcon from "./LinkViews/LinkComponents/LinkIcon";
+import { LinkIncludingShortenedCollectionAndTags } from "@linkwarden/types";
+import toast from "react-hot-toast";
+import { useUpdateLink } from "@linkwarden/router/links";
+import { useTranslation } from "react-i18next";
+import { restrictToWindowEdges, snapCenterToCursor } from "@dnd-kit/modifiers";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+
+interface DragNDropProps {
+  children: React.ReactNode;
+  /**
+   * The currently active link being dragged
+   */
+  activeLink: LinkIncludingShortenedCollectionAndTags | null;
+  /**
+   * All links available for drag and drop
+   */
+  links: LinkIncludingShortenedCollectionAndTags[];
+  setActiveLink: (link: LinkIncludingShortenedCollectionAndTags | null) => void;
+  /**
+   * Override the default sensors used for drag and drop.
+   */
+  sensors?: SensorDescriptor<SensorOptions>[];
+
+  /**
+   * Override onDragEnd function.
+   */
+  onDragEnd?: (event: DragEndEvent) => void;
+}
+
+/**
+ * Wrapper component for drag and drop functionality.
+ */
+export default function DragNDrop({
+  children,
+  activeLink,
+  links,
+  setActiveLink,
+  sensors: sensorProp,
+  onDragEnd: onDragEndProp,
+}: DragNDropProps) {
+  const { t } = useTranslation();
+  const updateLink = useUpdateLink();
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const draggedLink = links.find(
+      (link: any) => link.id === event.active.data.current?.linkId
+    );
+    setActiveLink(draggedLink || null);
+  };
+
+  const handleDragOverCancel = () => {
+    setActiveLink(null);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    // If an onDragEnd prop is provided, use it instead of the default behavior
+    if (onDragEndProp) {
+      onDragEndProp(event);
+      return;
+    }
+    const { over } = event;
+    if (!over || !activeLink) return;
+
+    const collectionId = over.data.current?.collectionId as number;
+    const collectionName = over.data.current?.collectionName as string;
+    const ownerId = over.data.current?.ownerId as number;
+
+    // Immediately hide the drag overlay
+    setActiveLink(null);
+
+    // if the link dropped over the same collection, toast
+    if (activeLink.collection.id === collectionId) {
+      toast.error(t("link_already_in_collection"));
+      return;
+    }
+
+    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+      ...activeLink,
+      collection: {
+        id: collectionId,
+        name: collectionName,
+        ownerId,
+      },
+    };
+
+    const load = toast.loading(t("updating"));
+    await updateLink.mutateAsync(updatedLink, {
+      onSettled: (_, error) => {
+        toast.dismiss(load);
+        if (error) {
+          toast.error(error.message);
+        } else {
+          toast.success(t("updated"));
+        }
+      },
+    });
+  };
+  return (
+    <DndContext
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragOverCancel}
+      modifiers={[restrictToWindowEdges, snapCenterToCursor]}
+      sensors={sensorProp ? sensorProp : sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
+    >
+      {!!activeLink && (
+        // when drag end, immediately hide the overlay
+        <DragOverlay
+          style={{
+            zIndex: 100,
+            pointerEvents: "none",
+          }}
+        >
+          <div className="w-fit h-fit">
+            <LinkIcon link={activeLink} />
+          </div>
+        </DragOverlay>
+      )}
+      {children}
+    </DndContext>
+  );
+}

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -5,6 +5,7 @@ const Droppable = ({
   children,
   id,
   data,
+  className,
 }: {
   children: React.ReactNode;
   id: string;
@@ -13,6 +14,7 @@ const Droppable = ({
     collectionName?: string;
     ownerId?: string;
   };
+  className?: string;
 }) => {
   const { setNodeRef, isOver } = useDroppable({
     id,
@@ -24,8 +26,9 @@ const Droppable = ({
       ref={setNodeRef}
       className={cn(
         isOver &&
-          "bg-primary/10 border-2 border-dashed border-primary rounded-lg",
-        "transition-colors duration-200"
+          "bg-primary/10 outline-2 outline-dashed outline-primary rounded-lg",
+        "transition-colors duration-200",
+        className
       )}
       style={{
         position: "relative",

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -13,6 +13,7 @@ const Droppable = ({
     collectionId?: string;
     collectionName?: string;
     ownerId?: string;
+    type?: "collection" | "tag";
   };
   className?: string;
 }) => {

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { useDroppable } from "@dnd-kit/core";
 
 const Droppable = ({
@@ -21,11 +22,11 @@ const Droppable = ({
   return (
     <div
       ref={setNodeRef}
-      className={`${
-        isOver
-          ? "bg-primary/10 border-2 border-dashed border-primary rounded-lg"
-          : ""
-      } transition-colors duration-200 p-2 min-h-20`}
+      className={cn(
+        isOver &&
+          "bg-primary/10 border-2 border-dashed border-primary rounded-lg",
+        "transition-colors duration-200"
+      )}
       style={{
         position: "relative",
         zIndex: isOver ? 1 : "auto",

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -21,6 +21,7 @@ const Droppable = ({
     data,
   });
 
+  const extraProps = isOver ? { "data-over": "" } : {};
   return (
     <div
       ref={setNodeRef}
@@ -30,6 +31,7 @@ const Droppable = ({
         "transition-colors duration-200",
         className
       )}
+      {...extraProps}
       style={{
         position: "relative",
         zIndex: isOver ? 1 : "auto",

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -10,8 +10,14 @@ const Droppable = ({
   children: React.ReactNode;
   id: string;
   data?: {
-    collectionId?: string;
-    collectionName?: string;
+    /**
+     * Id of collection or tag to drop into.
+     */
+    id?: string;
+    /**
+     * Name of collection or tag to drop into.
+     */
+    name?: string;
     ownerId?: string;
     type?: "collection" | "tag";
   };

--- a/apps/web/components/Droppable.tsx
+++ b/apps/web/components/Droppable.tsx
@@ -1,0 +1,39 @@
+import { useDroppable } from "@dnd-kit/core";
+
+const Droppable = ({
+  children,
+  id,
+  data,
+}: {
+  children: React.ReactNode;
+  id: string;
+  data?: {
+    collectionId?: string;
+    collectionName?: string;
+    ownerId?: string;
+  };
+}) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id,
+    data,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`${
+        isOver
+          ? "bg-primary/10 border-2 border-dashed border-primary rounded-lg"
+          : ""
+      } transition-colors duration-200 p-2 min-h-20`}
+      style={{
+        position: "relative",
+        zIndex: isOver ? 1 : "auto",
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Droppable;

--- a/apps/web/components/LinkViews/LinkComponents/LinkActions.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkActions.tsx
@@ -29,6 +29,8 @@ type Props = {
   className?: string;
   setLinkModal: (value: boolean) => void;
   ghost?: boolean;
+  onLinkDropdownMenuOpen: (value: boolean) => void;
+  dropdownMenuOpen: boolean;
 };
 
 export default function LinkActions({
@@ -37,6 +39,8 @@ export default function LinkActions({
   className,
   setLinkModal,
   ghost,
+  onLinkDropdownMenuOpen,
+  dropdownMenuOpen,
 }: Props) {
   const { t } = useTranslation();
 
@@ -91,7 +95,10 @@ export default function LinkActions({
           <i title="More" className="bi-info-circle text-xl" />
         </Button>
       ) : (
-        <DropdownMenu>
+        <DropdownMenu
+          open={dropdownMenuOpen}
+          onOpenChange={onLinkDropdownMenuOpen}
+        >
           <DropdownMenuTrigger asChild>
             <Button
               asChild

--- a/apps/web/components/LinkViews/LinkComponents/LinkActions.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkActions.tsx
@@ -29,8 +29,6 @@ type Props = {
   className?: string;
   setLinkModal: (value: boolean) => void;
   ghost?: boolean;
-  onLinkDropdownMenuOpen: (value: boolean) => void;
-  dropdownMenuOpen: boolean;
 };
 
 export default function LinkActions({
@@ -39,8 +37,6 @@ export default function LinkActions({
   className,
   setLinkModal,
   ghost,
-  onLinkDropdownMenuOpen,
-  dropdownMenuOpen,
 }: Props) {
   const { t } = useTranslation();
 
@@ -95,10 +91,7 @@ export default function LinkActions({
           <i title="More" className="bi-info-circle text-xl" />
         </Button>
       ) : (
-        <DropdownMenu
-          open={dropdownMenuOpen}
-          onOpenChange={onLinkDropdownMenuOpen}
-        >
+        <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               asChild

--- a/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
@@ -150,11 +150,9 @@ export default function LinkCard({ link, columns, editMode }: Props) {
     };
   }, [isVisible, link.preview]);
 
-  const selectedStyle = selectedLinks.some(
+  const isLinkSelected = selectedLinks.some(
     (selectedLink) => selectedLink.id === link.id
-  )
-    ? "border-primary bg-base-300"
-    : "border-neutral-content";
+  );
 
   const selectable =
     editMode &&
@@ -166,8 +164,8 @@ export default function LinkCard({ link, columns, editMode }: Props) {
       {...listeners}
       {...attributes}
       className={cn(
-        selectedStyle,
         "border border-solid border-neutral-content bg-base-200 shadow-md hover:shadow-none duration-100 rounded-xl relative group",
+        isLinkSelected && "border-primary bg-base-300",
         isDragging ? "opacity-30" : "opacity-100",
         "relative group touch-manipulation select-none"
       )}

--- a/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
@@ -29,10 +29,11 @@ import LinkPin from "./LinkPin";
 import LinkFormats from "./LinkFormats";
 import openLink from "@/lib/client/openLink";
 import { Separator } from "@/components/ui/separator";
+import { useDraggable } from "@dnd-kit/core";
+import { cn } from "@/lib/utils";
 
 type Props = {
   link: LinkIncludingShortenedCollectionAndTags;
-  count: number;
   columns: number;
   className?: string;
   editMode?: boolean;
@@ -40,6 +41,12 @@ type Props = {
 
 export default function LinkCard({ link, columns, editMode }: Props) {
   const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: link.id?.toString() ?? "",
+    data: {
+      linkId: link.id,
+    },
+  });
 
   const heightMap = {
     1: "h-44",
@@ -155,8 +162,15 @@ export default function LinkCard({ link, columns, editMode }: Props) {
 
   return (
     <div
-      ref={ref}
-      className={`${selectedStyle} border border-solid border-neutral-content bg-base-200 shadow-md hover:shadow-none duration-100 rounded-xl relative group`}
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={cn(
+        selectedStyle,
+        "border border-solid border-neutral-content bg-base-200 shadow-md hover:shadow-none duration-100 rounded-xl relative group",
+        isDragging ? "opacity-30" : "opacity-100",
+        "relative group touch-manipulation select-none"
+      )}
       onClick={() =>
         selectable
           ? handleCheckboxClick(link)
@@ -165,95 +179,97 @@ export default function LinkCard({ link, columns, editMode }: Props) {
             : undefined
       }
     >
-      <div
-        className="rounded-xl cursor-pointer h-full flex flex-col justify-between"
-        onClick={() =>
-          !editMode && openLink(link, user, () => setLinkModal(true))
-        }
-      >
-        {show.image && (
-          <div>
-            <div
-              className={`relative rounded-t-xl ${imageHeightClass} overflow-hidden`}
-            >
-              {formatAvailable(link, "preview") ? (
-                <Image
-                  src={`/api/v1/archives/${link.id}?format=${ArchivedFormat.jpeg}&preview=true&updatedAt=${link.updatedAt}`}
-                  width={1280}
-                  height={720}
-                  alt=""
-                  className={`rounded-t-xl select-none object-cover z-10 ${imageHeightClass} w-full shadow opacity-80 scale-105`}
-                  style={show.icon ? { filter: "blur(1px)" } : undefined}
-                  draggable="false"
-                  onError={(e) => {
-                    const target = e.target as HTMLElement;
-                    target.style.display = "none";
-                  }}
-                />
-              ) : link.preview === "unavailable" ? (
-                <div
-                  className={`bg-gray-50 ${imageHeightClass} bg-opacity-80`}
-                ></div>
-              ) : (
-                <div
-                  className={`${imageHeightClass} bg-opacity-80 skeleton rounded-none`}
-                ></div>
-              )}
-              {show.icon && (
-                <div className="absolute top-0 left-0 right-0 bottom-0 rounded-t-xl flex items-center justify-center rounded-md">
-                  <LinkIcon link={link} />
-                </div>
-              )}
-              {show.preserved_formats &&
-                link.type === "url" &&
-                atLeastOneFormatAvailable(link) && (
-                  <div className="absolute bottom-0 right-0 m-2 bg-base-200 bg-opacity-60 px-1 rounded-md">
-                    <LinkFormats link={link} />
-                  </div>
-                )}
-            </div>
-            <Separator />
-          </div>
-        )}
-
-        <div className="flex flex-col justify-between h-full min-h-24">
-          <div className="p-3 flex flex-col gap-2">
-            {show.name && (
-              <p className="truncate w-full text-primary text-sm">
-                {unescapeString(link.name)}
-              </p>
-            )}
-
-            {show.link && <LinkTypeBadge link={link} />}
-          </div>
-
-          {(show.collection || show.date) && (
+      <div ref={ref}>
+        <div
+          className="rounded-xl cursor-pointer h-full flex flex-col justify-between"
+          onClick={() =>
+            !editMode && openLink(link, user, () => setLinkModal(true))
+          }
+        >
+          {show.image && (
             <div>
-              <Separator className="mb-1" />
-
-              <div className="flex justify-between items-center text-xs text-neutral px-3 pb-1 gap-2">
-                {show.collection && !isPublicRoute && (
-                  <div className="cursor-pointer truncate">
-                    <LinkCollection link={link} collection={collection} />
+              <div
+                className={`relative rounded-t-xl ${imageHeightClass} overflow-hidden`}
+              >
+                {formatAvailable(link, "preview") ? (
+                  <Image
+                    src={`/api/v1/archives/${link.id}?format=${ArchivedFormat.jpeg}&preview=true&updatedAt=${link.updatedAt}`}
+                    width={1280}
+                    height={720}
+                    alt=""
+                    className={`rounded-t-xl select-none object-cover z-10 ${imageHeightClass} w-full shadow opacity-80 scale-105`}
+                    style={show.icon ? { filter: "blur(1px)" } : undefined}
+                    draggable="false"
+                    onError={(e) => {
+                      const target = e.target as HTMLElement;
+                      target.style.display = "none";
+                    }}
+                  />
+                ) : link.preview === "unavailable" ? (
+                  <div
+                    className={`bg-gray-50 ${imageHeightClass} bg-opacity-80`}
+                  ></div>
+                ) : (
+                  <div
+                    className={`${imageHeightClass} bg-opacity-80 skeleton rounded-none`}
+                  ></div>
+                )}
+                {show.icon && (
+                  <div className="absolute top-0 left-0 right-0 bottom-0 rounded-t-xl flex items-center justify-center rounded-md">
+                    <LinkIcon link={link} />
                   </div>
                 )}
-                {show.date && <LinkDate link={link} />}
+                {show.preserved_formats &&
+                  link.type === "url" &&
+                  atLeastOneFormatAvailable(link) && (
+                    <div className="absolute bottom-0 right-0 m-2 bg-base-200 bg-opacity-60 px-1 rounded-md">
+                      <LinkFormats link={link} />
+                    </div>
+                  )}
               </div>
+              <Separator />
             </div>
           )}
-        </div>
-      </div>
 
-      {/* Overlay on hover */}
-      <div className="absolute pointer-events-none top-0 left-0 right-0 bottom-0 bg-base-100 bg-opacity-0 group-hover:bg-opacity-20 group-focus-within:opacity-20 rounded-xl duration-100"></div>
-      <LinkActions
-        link={link}
-        collection={collection}
-        linkModal={linkModal}
-        setLinkModal={(e) => setLinkModal(e)}
-        className="absolute top-3 right-3 group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral z-20"
-      />
-      {!isPublicRoute && <LinkPin link={link} />}
+          <div className="flex flex-col justify-between h-full min-h-24">
+            <div className="p-3 flex flex-col gap-2">
+              {show.name && (
+                <p className="truncate w-full text-primary text-sm">
+                  {unescapeString(link.name)}
+                </p>
+              )}
+
+              {show.link && <LinkTypeBadge link={link} />}
+            </div>
+
+            {(show.collection || show.date) && (
+              <div>
+                <Separator className="mb-1" />
+
+                <div className="flex justify-between items-center text-xs text-neutral px-3 pb-1 gap-2">
+                  {show.collection && !isPublicRoute && (
+                    <div className="cursor-pointer truncate">
+                      <LinkCollection link={link} collection={collection} />
+                    </div>
+                  )}
+                  {show.date && <LinkDate link={link} />}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Overlay on hover */}
+        <div className="absolute pointer-events-none top-0 left-0 right-0 bottom-0 bg-base-100 bg-opacity-0 group-hover:bg-opacity-20 group-focus-within:opacity-20 rounded-xl duration-100"></div>
+        <LinkActions
+          link={link}
+          collection={collection}
+          linkModal={linkModal}
+          setLinkModal={(e) => setLinkModal(e)}
+          className="absolute top-3 right-3 group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral z-20"
+        />
+        {!isPublicRoute && <LinkPin link={link} />}
+      </div>
     </div>
   );
 }

--- a/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkCard.tsx
@@ -31,6 +31,7 @@ import openLink from "@/lib/client/openLink";
 import { Separator } from "@/components/ui/separator";
 import { useDraggable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
+import useMediaQuery from "@/hooks/useMediaQuery";
 
 type Props = {
   link: LinkIncludingShortenedCollectionAndTags;
@@ -41,11 +42,15 @@ type Props = {
 
 export default function LinkCard({ link, columns, editMode }: Props) {
   const { t } = useTranslation();
+
+  // we don't want to use the draggable feature for screen under 1023px since the sidebar is hidden
+  const isSmallScreen = useMediaQuery("(max-width: 1023px)");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: link.id?.toString() ?? "",
     data: {
       linkId: link.id,
     },
+    disabled: isSmallScreen,
   });
 
   const heightMap = {

--- a/apps/web/components/LinkViews/LinkComponents/LinkList.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkList.tsx
@@ -9,7 +9,7 @@ import LinkActions from "@/components/LinkViews/LinkComponents/LinkActions";
 import LinkDate from "@/components/LinkViews/LinkComponents/LinkDate";
 import LinkCollection from "@/components/LinkViews/LinkComponents/LinkCollection";
 import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
-import { isPWA } from "@/lib/utils";
+import { cn, isPWA } from "@/lib/utils";
 import usePermissions from "@/hooks/usePermissions";
 import toast from "react-hot-toast";
 import LinkTypeBadge from "./LinkTypeBadge";
@@ -23,6 +23,8 @@ import { useRouter } from "next/router";
 import { atLeastOneFormatAvailable } from "@linkwarden/lib/formatStats";
 import LinkFormats from "./LinkFormats";
 import openLink from "@/lib/client/openLink";
+import { useDraggable } from "@dnd-kit/core";
+import useMediaQuery from "@/hooks/useMediaQuery";
 
 type Props = {
   link: LinkIncludingShortenedCollectionAndTags;
@@ -33,6 +35,15 @@ type Props = {
 
 export default function LinkCardCompact({ link, editMode }: Props) {
   const { t } = useTranslation();
+
+  const isSmallScreen = useMediaQuery("(max-width: 1023px)");
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: link.id?.toString() ?? "",
+    data: {
+      linkId: link.id,
+    },
+    disabled: isSmallScreen,
+  });
 
   const { data: collections = [] } = useCollections();
 
@@ -103,9 +114,16 @@ export default function LinkCardCompact({ link, editMode }: Props) {
   return (
     <>
       <div
-        className={`${selectedStyle} rounded-md border relative group items-center flex ${
-          !isPWA() ? "hover:bg-base-300 px-2 py-1" : "py-1"
-        } duration-200`}
+        ref={setNodeRef}
+        {...attributes}
+        {...listeners}
+        className={cn(
+          "rounded-md border relative group items-center flex",
+          selectedStyle,
+          !isPWA() ? "hover:bg-base-300 px-2 py-1" : "py-1",
+          isDragging ? "opacity-30" : "opacity-100",
+          "duration-200, touch-manipulation select-none"
+        )}
         onClick={() =>
           selectable
             ? handleCheckboxClick(link)

--- a/apps/web/components/LinkViews/LinkComponents/LinkPin.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkPin.tsx
@@ -21,7 +21,7 @@ export default function LinkPin({ link, btnStyle }: Props) {
       variant="simple"
       size="icon"
       className={clsx(
-        "absolute top-3 right-[3.25rem] group-hover:opacity-100 opacity-0 duration-100 text-neutral",
+        "absolute top-3 right-[3.25rem] group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral",
         btnStyle
       )}
       onClick={() => pinLink(link)}

--- a/apps/web/components/LinkViews/LinkComponents/LinkPin.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkPin.tsx
@@ -21,7 +21,7 @@ export default function LinkPin({ link, btnStyle }: Props) {
       variant="simple"
       size="icon"
       className={clsx(
-        "absolute top-3 right-[3.25rem] group-hover:opacity-100 group-focus-within:opacity-100 opacity-0 duration-100 text-neutral",
+        "absolute top-3 right-[3.25rem] group-hover:opacity-100 opacity-0 duration-100 text-neutral",
         btnStyle
       )}
       onClick={() => pinLink(link)}

--- a/apps/web/components/LinkViews/Links.tsx
+++ b/apps/web/components/LinkViews/Links.tsx
@@ -87,7 +87,6 @@ export function CardView({
           <LinkCard
             key={i}
             link={e}
-            count={i}
             editMode={editMode}
             columns={columnCount}
           />

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import CollectionListing from "@/components/CollectionListing";
 import { useTranslation } from "next-i18next";
 import { useCollections } from "@linkwarden/router/collections";
 import { useTags } from "@linkwarden/router/tags";
+import { TagListing } from "./TagListing";
 
 export default function Sidebar({ className }: { className?: string }) {
   const { t } = useTranslation();
@@ -134,36 +135,8 @@ export default function Sidebar({ className }: { className?: string }) {
                 <div className="skeleton h-4 w-full"></div>
                 <div className="skeleton h-4 w-full"></div>
               </div>
-            ) : tags[0] ? (
-              tags
-                .sort((a: any, b: any) => a.name.localeCompare(b.name))
-                .map((e: any, i: any) => {
-                  return (
-                    <Link key={i} href={`/tags/${e.id}`}>
-                      <div
-                        className={`${
-                          active === `/tags/${e.id}`
-                            ? "bg-primary/20"
-                            : "hover:bg-neutral/20"
-                        } duration-100 py-1 px-2 cursor-pointer flex items-center gap-2 w-full rounded-md h-8`}
-                      >
-                        <i className="bi-hash text-xl text-primary drop-shadow"></i>
-                        <p className="truncate w-full pr-7">{e.name}</p>
-                        <div className="drop-shadow text-neutral text-xs">
-                          {e._count?.links}
-                        </div>
-                      </div>
-                    </Link>
-                  );
-                })
             ) : (
-              <div
-                className={`duration-100 py-1 px-2 flex items-center gap-2 w-full rounded-md h-8 capitalize`}
-              >
-                <p className="text-neutral text-xs font-semibold truncate w-full pr-7">
-                  {t("you_have_no_tags")}
-                </p>
-              </div>
+              <TagListing tags={tags} active={active} />
             )}
           </Disclosure.Panel>
         </Transition>

--- a/apps/web/components/TagListing.tsx
+++ b/apps/web/components/TagListing.tsx
@@ -1,0 +1,51 @@
+import { Tag } from "@linkwarden/prisma/client";
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import Droppable from "./Droppable";
+
+interface TagListingProps {
+  tags: Tag[];
+  active?: string;
+}
+export function TagListing({ tags, active }: TagListingProps) {
+  const { t } = useTranslation();
+  if (!tags[0]) {
+    return (
+      <div
+        className={`duration-100 py-1 px-2 flex items-center gap-2 w-full rounded-md h-8 capitalize`}
+      >
+        <p className="text-neutral text-xs font-semibold truncate w-full pr-7">
+          {t("you_have_no_tags")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {tags
+        .sort((a: any, b: any) => a.name.localeCompare(b.name))
+        .map((e: any, i: any) => {
+          return (
+            <Droppable id={`tag-${e.id}`} key={i}>
+              <Link key={i} href={`/tags/${e.id}`}>
+                <div
+                  className={`${
+                    active === `/tags/${e.id}`
+                      ? "bg-primary/20"
+                      : "hover:bg-neutral/20"
+                  } duration-100 py-1 px-2 cursor-pointer flex items-center gap-2 w-full rounded-md h-8`}
+                >
+                  <i className="bi-hash text-xl text-primary drop-shadow"></i>
+                  <p className="truncate w-full pr-7">{e.name}</p>
+                  <div className="drop-shadow text-neutral text-xs">
+                    {e._count?.links}
+                  </div>
+                </div>
+              </Link>
+            </Droppable>
+          );
+        })}
+    </>
+  );
+}

--- a/apps/web/components/TagListing.tsx
+++ b/apps/web/components/TagListing.tsx
@@ -2,6 +2,7 @@ import { Tag } from "@linkwarden/prisma/client";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import Droppable from "./Droppable";
+import { cn } from "@linkwarden/lib";
 
 interface TagListingProps {
   tags: Tag[];
@@ -27,14 +28,20 @@ export function TagListing({ tags, active }: TagListingProps) {
         .sort((a: any, b: any) => a.name.localeCompare(b.name))
         .map((e: any, i: any) => {
           return (
-            <Droppable id={`tag-${e.id}`} key={i}>
+            <Droppable
+              id={`tag-${e.id}`}
+              key={i}
+              className="group"
+              data={{ type: "tag", id: e.id, name: e.name }}
+            >
               <Link key={i} href={`/tags/${e.id}`}>
                 <div
-                  className={`${
+                  className={cn(
                     active === `/tags/${e.id}`
                       ? "bg-primary/20"
-                      : "hover:bg-neutral/20"
-                  } duration-100 py-1 px-2 cursor-pointer flex items-center gap-2 w-full rounded-md h-8`}
+                      : "group-[&:not([data-over])]:hover:bg-neutral/20",
+                    "duration-100 py-1 px-2 cursor-pointer flex items-center gap-2 w-full rounded-md h-8"
+                  )}
                 >
                   <i className="bi-hash text-xl text-primary drop-shadow"></i>
                   <p className="truncate w-full pr-7">{e.name}</p>

--- a/apps/web/hooks/useMediaQuery.tsx
+++ b/apps/web/hooks/useMediaQuery.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export default function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(false);
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+    // Set initial state
+    setMatches(mediaQueryList.matches);
+    // Add listener for changes
+    mediaQueryList.addEventListener("change", handleChange);
+    // Cleanup listener on unmount
+    return () => {
+      mediaQueryList.removeEventListener("change", handleChange);
+    };
+  }, [query]);
+  return matches;
+}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,3 +1,4 @@
+import { pointerWithin, rectIntersection } from "@dnd-kit/core";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -18,4 +19,22 @@ export function isIphone() {
     /iPhone/.test(navigator.userAgent) &&
     !(window as unknown as { MSStream?: any }).MSStream
   );
+}
+
+/**
+ *
+ * Custom collision detection algorithm for dnd-kit that first checks for pointer collisions
+ * and then falls back to rectangle intersections
+ */
+export function customCollisionDetectionAlgorithm(args: any) {
+  // First, let's see if there are any collisions with the pointer
+  const pointerCollisions = pointerWithin(args);
+
+  // Collision detection algorithms return an array of collisions
+  if (pointerCollisions.length > 0) {
+    return pointerCollisions;
+  }
+
+  // If there are no collisions with the pointer, return rectangle intersections
+  return rectIntersection(args);
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@atlaskit/tree": "^8.8.7",
     "@auth/prisma-adapter": "^1.0.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@headlessui/react": "^1.7.15",
     "@linkwarden/filesystem": "*",
     "@linkwarden/lib": "*",

--- a/apps/web/pages/collections/[id].tsx
+++ b/apps/web/pages/collections/[id].tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "next-i18next";
 import LinkListOptions from "@/components/LinkListOptions";
 import { useCollections } from "@linkwarden/router/collections";
 import { useUser } from "@linkwarden/router/user";
-import { useLinks, useUpdateLink } from "@linkwarden/router/links";
+import { useLinks } from "@linkwarden/router/links";
 import Links from "@/components/LinkViews/Links";
 import Icon from "@/components/Icon";
 import CollectionCard from "@/components/CollectionCard";
@@ -36,25 +36,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import {
-  DndContext,
-  DragEndEvent,
-  DragOverlay,
-  DragStartEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import toast from "react-hot-toast";
-import { customCollisionDetectionAlgorithm } from "@/lib/utils";
-import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
-import { snapCenterToCursor } from "@dnd-kit/modifiers";
+import DragNDrop from "@/components/DragNDrop";
 
 export default function Index() {
   const { t } = useTranslation();
   const router = useRouter();
-  const updateLink = useUpdateLink();
 
   const { data: collections = [] } = useCollections();
 
@@ -69,22 +55,6 @@ export default function Index() {
 
   const [activeLink, setActiveLink] =
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
-
-  const mouseSensor = useSensor(MouseSensor, {
-    // Require the mouse to move by 10 pixels before activating
-    activationConstraint: {
-      distance: 10,
-    },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    // Press delay of 250ms, with tolerance of 5px of movement
-    activationConstraint: {
-      delay: 200,
-      tolerance: 5,
-    },
-  });
-
-  const sensors = useSensors(mouseSensor, touchSensor);
 
   const [activeCollection, setActiveCollection] =
     useState<CollectionIncludingMembersAndLinkCount>();
@@ -141,73 +111,13 @@ export default function Index() {
     (localStorage.getItem("viewMode") as ViewMode) || ViewMode.Card
   );
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const draggedLink = links.find(
-      (link: any) => link.id === event.active.data.current?.linkId
-    );
-    setActiveLink(draggedLink || null);
-  };
-
-  const handleDragOverCancel = () => {
-    setActiveLink(null);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { over } = event;
-    if (!over || !activeLink) return;
-
-    const collectionId = over.data.current?.collectionId as number;
-    const collectionName = over.data.current?.collectionName as string;
-    const ownerId = over.data.current?.ownerId as number;
-
-    // Immediately hide the drag overlay
-    setActiveLink(null);
-
-    // if the link dropped over the same collection, toast
-    if (activeLink.collection.id === collectionId) {
-      toast.error(t("link_already_in_collection"));
-      return;
-    }
-
-    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
-      ...activeLink,
-      collection: {
-        id: collectionId,
-        name: collectionName,
-        ownerId,
-      },
-    };
-
-    const load = toast.loading(t("updating"));
-    await updateLink.mutateAsync(updatedLink, {
-      onSettled: (_, error) => {
-        toast.dismiss(load);
-        if (error) {
-          toast.error(error.message);
-        } else {
-          toast.success(t("updated"));
-        }
-      },
-    });
-  };
-
   return (
-    <DndContext
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragOverCancel}
-      sensors={sensors}
-      collisionDetection={customCollisionDetectionAlgorithm}
-      modifiers={[snapCenterToCursor]}
+    <DragNDrop
+      links={links}
+      activeLink={activeLink}
+      setActiveLink={setActiveLink}
     >
       <MainLayout>
-        {!!activeLink && (
-          <DragOverlay className="z-50 pointer-events-none">
-            <div className="w-fit h-fit">
-              <LinkIcon link={activeLink} />
-            </div>
-          </DragOverlay>
-        )}
         <div
           className="p-5 flex gap-3 flex-col"
           style={{
@@ -494,7 +404,7 @@ export default function Index() {
           </>
         )}
       </MainLayout>
-    </DndContext>
+    </DragNDrop>
   );
 }
 

--- a/apps/web/pages/collections/[id].tsx
+++ b/apps/web/pages/collections/[id].tsx
@@ -1,6 +1,7 @@
 import {
   AccountSettings,
   CollectionIncludingMembersAndLinkCount,
+  LinkIncludingShortenedCollectionAndTags,
   Sort,
   ViewMode,
 } from "@linkwarden/types";
@@ -20,7 +21,7 @@ import { useTranslation } from "next-i18next";
 import LinkListOptions from "@/components/LinkListOptions";
 import { useCollections } from "@linkwarden/router/collections";
 import { useUser } from "@linkwarden/router/user";
-import { useLinks } from "@linkwarden/router/links";
+import { useLinks, useUpdateLink } from "@linkwarden/router/links";
 import Links from "@/components/LinkViews/Links";
 import Icon from "@/components/Icon";
 import CollectionCard from "@/components/CollectionCard";
@@ -35,10 +36,25 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import toast from "react-hot-toast";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
+import { snapCenterToCursor } from "@dnd-kit/modifiers";
 
 export default function Index() {
   const { t } = useTranslation();
   const router = useRouter();
+  const updateLink = useUpdateLink();
 
   const { data: collections = [] } = useCollections();
 
@@ -50,6 +66,25 @@ export default function Index() {
     sort: sortBy,
     collectionId: Number(router.query.id),
   });
+
+  const [activeLink, setActiveLink] =
+    useState<LinkIncludingShortenedCollectionAndTags | null>(null);
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
 
   const [activeCollection, setActiveCollection] =
     useState<CollectionIncludingMembersAndLinkCount>();
@@ -106,290 +141,360 @@ export default function Index() {
     (localStorage.getItem("viewMode") as ViewMode) || ViewMode.Card
   );
 
+  const handleDragStart = (event: DragStartEvent) => {
+    const draggedLink = links.find(
+      (link: any) => link.id === event.active.data.current?.linkId
+    );
+    setActiveLink(draggedLink || null);
+  };
+
+  const handleDragOverCancel = () => {
+    setActiveLink(null);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { over } = event;
+    if (!over || !activeLink) return;
+
+    const collectionId = over.data.current?.collectionId as number;
+    const collectionName = over.data.current?.collectionName as string;
+    const ownerId = over.data.current?.ownerId as number;
+
+    // Immediately hide the drag overlay
+    setActiveLink(null);
+
+    // if the link dropped over the same collection, toast
+    if (activeLink.collection.id === collectionId) {
+      toast.error(t("link_already_in_collection"));
+      return;
+    }
+
+    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+      ...activeLink,
+      collection: {
+        id: collectionId,
+        name: collectionName,
+        ownerId,
+      },
+    };
+
+    const load = toast.loading(t("updating"));
+    await updateLink.mutateAsync(updatedLink, {
+      onSettled: (_, error) => {
+        toast.dismiss(load);
+        if (error) {
+          toast.error(error.message);
+        } else {
+          toast.success(t("updated"));
+        }
+      },
+    });
+  };
+
   return (
-    <MainLayout>
-      <div
-        className="p-5 flex gap-3 flex-col"
-        style={{
-          backgroundImage: `linear-gradient(${activeCollection?.color}20 0%, ${
-            user?.theme === "dark" ? "#262626" : "#f3f4f6"
-          } 13rem, ${user?.theme === "dark" ? "#171717" : "#ffffff"} 100%)`,
-        }}
-      >
-        {activeCollection && (
-          <div className="flex gap-3 items-start justify-between">
-            <div className="flex items-center gap-2">
-              {activeCollection.icon ? (
-                <Icon
-                  icon={activeCollection.icon}
-                  size={45}
-                  weight={
-                    (activeCollection.iconWeight || "regular") as IconWeight
-                  }
-                  color={activeCollection.color}
-                />
-              ) : (
-                <i
-                  className="bi-folder-fill text-3xl"
-                  style={{ color: activeCollection.color }}
-                />
-              )}
-
-              <p className="sm:text-3xl text-2xl w-full py-1 break-words hyphens-auto font-thin">
-                {activeCollection?.name}
-              </p>
+    <DndContext
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragOverCancel}
+      sensors={sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
+      modifiers={[snapCenterToCursor]}
+    >
+      <MainLayout>
+        {!!activeLink && (
+          <DragOverlay className="z-50 pointer-events-none">
+            <div className="w-fit h-fit">
+              <LinkIcon link={activeLink} />
             </div>
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="icon"
-                  className="mt-2 text-neutral"
-                  onMouseDown={(e) => e.preventDefault()}
-                  title={t("more")}
-                >
-                  <i className="bi-three-dots text-xl" />
-                </Button>
-              </DropdownMenuTrigger>
-
-              <DropdownMenuContent
-                sideOffset={4}
-                align="end"
-                className="bg-base-200 border border-neutral-content rounded-box p-1"
-              >
-                <DropdownMenuItem
-                  onClick={() => {
-                    for (const link of links) {
-                      if (link.url) window.open(link.url, "_blank");
-                    }
-                  }}
-                >
-                  <i className="bi-box-arrow-up-right" />
-                  {t("open_all_links")}
-                </DropdownMenuItem>
-
-                {permissions === true && (
-                  <DropdownMenuItem
-                    onClick={() => setEditCollectionModal(true)}
-                  >
-                    <i className="bi-pencil-square" />
-                    {t("edit_collection_info")}
-                  </DropdownMenuItem>
-                )}
-
-                <DropdownMenuItem
-                  onClick={() => setEditCollectionSharingModal(true)}
-                >
-                  <i className="bi-globe" />
-                  {permissions === true
-                    ? t("share_and_collaborate")
-                    : t("view_team")}
-                </DropdownMenuItem>
-
-                {permissions === true && (
-                  <DropdownMenuItem onClick={() => setNewCollectionModal(true)}>
-                    <i className="bi-folder-plus" />
-                    {t("create_subcollection")}
-                  </DropdownMenuItem>
-                )}
-
-                <DropdownMenuSeparator />
-
-                <DropdownMenuItem
-                  onClick={() => setDeleteCollectionModal(true)}
-                  className="text-error"
-                >
-                  {permissions === true ? (
-                    <>
-                      <i className="bi-trash" />
-                      {t("delete_collection")}
-                    </>
-                  ) : (
-                    <>
-                      <i className="bi-box-arrow-left" />
-                      {t("leave_collection")}
-                    </>
-                  )}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          </DragOverlay>
         )}
-
-        {activeCollection && (
-          <div className="min-w-[15rem]">
-            <div className="flex gap-1 justify-center sm:justify-end items-center w-fit">
-              <div
-                className="flex items-center px-1 py-1 rounded-full cursor-pointer hover:bg-base-content/20 transition-colors duration-200"
-                onClick={() => setEditCollectionSharingModal(true)}
-              >
-                {collectionOwner.id && (
-                  <ProfilePhoto
-                    src={collectionOwner.image || undefined}
-                    name={collectionOwner.name}
+        <div
+          className="p-5 flex gap-3 flex-col"
+          style={{
+            backgroundImage: `linear-gradient(${activeCollection?.color}20 0%, ${
+              user?.theme === "dark" ? "#262626" : "#f3f4f6"
+            } 13rem, ${user?.theme === "dark" ? "#171717" : "#ffffff"} 100%)`,
+          }}
+        >
+          {activeCollection && (
+            <div className="flex gap-3 items-start justify-between">
+              <div className="flex items-center gap-2">
+                {activeCollection.icon ? (
+                  <Icon
+                    icon={activeCollection.icon}
+                    size={45}
+                    weight={
+                      (activeCollection.iconWeight || "regular") as IconWeight
+                    }
+                    color={activeCollection.color}
+                  />
+                ) : (
+                  <i
+                    className="bi-folder-fill text-3xl"
+                    style={{ color: activeCollection.color }}
                   />
                 )}
-                {activeCollection.members
-                  .sort((a, b) => (a.userId as number) - (b.userId as number))
-                  .map((e, i) => {
-                    return (
-                      <ProfilePhoto
-                        key={i}
-                        src={e.user.image ? e.user.image : undefined}
-                        name={e.user.name}
-                        className="-ml-3"
-                      />
-                    );
-                  })
-                  .slice(0, 3)}
-                {activeCollection.members.length - 3 > 0 && (
-                  <div className={`avatar drop-shadow-md placeholder -ml-3`}>
-                    <div className="bg-base-100 text-neutral rounded-full w-8 h-8 ring-2 ring-neutral-content">
-                      <span>+{activeCollection.members.length - 3}</span>
-                    </div>
-                  </div>
-                )}
+
+                <p className="sm:text-3xl text-2xl w-full py-1 break-words hyphens-auto font-thin">
+                  {activeCollection?.name}
+                </p>
               </div>
 
-              <p className="text-neutral text-sm ml-2">
-                {activeCollection.members.length > 0
-                  ? activeCollection.members.length === 1
-                    ? t("by_author_and_other", {
-                        author: collectionOwner.name,
-                        count: activeCollection.members.length,
-                      })
-                    : t("by_author_and_others", {
-                        author: collectionOwner.name,
-                        count: activeCollection.members.length,
-                      })
-                  : t("by_author", { author: collectionOwner.name })}
-              </p>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="icon"
+                    className="mt-2 text-neutral"
+                    onMouseDown={(e) => e.preventDefault()}
+                    title={t("more")}
+                  >
+                    <i className="bi-three-dots text-xl" />
+                  </Button>
+                </DropdownMenuTrigger>
+
+                <DropdownMenuContent
+                  sideOffset={4}
+                  align="end"
+                  className="bg-base-200 border border-neutral-content rounded-box p-1"
+                >
+                  <DropdownMenuItem
+                    onClick={() => {
+                      for (const link of links) {
+                        if (link.url) window.open(link.url, "_blank");
+                      }
+                    }}
+                  >
+                    <i className="bi-box-arrow-up-right" />
+                    {t("open_all_links")}
+                  </DropdownMenuItem>
+
+                  {permissions === true && (
+                    <DropdownMenuItem
+                      onClick={() => setEditCollectionModal(true)}
+                    >
+                      <i className="bi-pencil-square" />
+                      {t("edit_collection_info")}
+                    </DropdownMenuItem>
+                  )}
+
+                  <DropdownMenuItem
+                    onClick={() => setEditCollectionSharingModal(true)}
+                  >
+                    <i className="bi-globe" />
+                    {permissions === true
+                      ? t("share_and_collaborate")
+                      : t("view_team")}
+                  </DropdownMenuItem>
+
+                  {permissions === true && (
+                    <DropdownMenuItem
+                      onClick={() => setNewCollectionModal(true)}
+                    >
+                      <i className="bi-folder-plus" />
+                      {t("create_subcollection")}
+                    </DropdownMenuItem>
+                  )}
+
+                  <DropdownMenuSeparator />
+
+                  <DropdownMenuItem
+                    onClick={() => setDeleteCollectionModal(true)}
+                    className="text-error"
+                  >
+                    {permissions === true ? (
+                      <>
+                        <i className="bi-trash" />
+                        {t("delete_collection")}
+                      </>
+                    ) : (
+                      <>
+                        <i className="bi-box-arrow-left" />
+                        {t("leave_collection")}
+                      </>
+                    )}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
-          </div>
-        )}
+          )}
 
-        {activeCollection?.description && <p>{activeCollection.description}</p>}
+          {activeCollection && (
+            <div className="min-w-[15rem]">
+              <div className="flex gap-1 justify-center sm:justify-end items-center w-fit">
+                <div
+                  className="flex items-center px-1 py-1 rounded-full cursor-pointer hover:bg-base-content/20 transition-colors duration-200"
+                  onClick={() => setEditCollectionSharingModal(true)}
+                >
+                  {collectionOwner.id && (
+                    <ProfilePhoto
+                      src={collectionOwner.image || undefined}
+                      name={collectionOwner.name}
+                    />
+                  )}
+                  {activeCollection.members
+                    .sort((a, b) => (a.userId as number) - (b.userId as number))
+                    .map((e, i) => {
+                      return (
+                        <ProfilePhoto
+                          key={i}
+                          src={e.user.image ? e.user.image : undefined}
+                          name={e.user.name}
+                          className="-ml-3"
+                        />
+                      );
+                    })
+                    .slice(0, 3)}
+                  {activeCollection.members.length - 3 > 0 && (
+                    <div className={`avatar drop-shadow-md placeholder -ml-3`}>
+                      <div className="bg-base-100 text-neutral rounded-full w-8 h-8 ring-2 ring-neutral-content">
+                        <span>+{activeCollection.members.length - 3}</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
 
-        <Separator />
+                <p className="text-neutral text-sm ml-2">
+                  {activeCollection.members.length > 0
+                    ? activeCollection.members.length === 1
+                      ? t("by_author_and_other", {
+                          author: collectionOwner.name,
+                          count: activeCollection.members.length,
+                        })
+                      : t("by_author_and_others", {
+                          author: collectionOwner.name,
+                          count: activeCollection.members.length,
+                        })
+                    : t("by_author", { author: collectionOwner.name })}
+                </p>
+              </div>
+            </div>
+          )}
 
-        {collections.some((e) => e.parentId === activeCollection?.id) && (
-          <>
-            <PageHeader
-              icon="bi-folder"
-              title={t("collections")}
-              description={t(
-                collections.filter((e) => e.parentId === activeCollection?.id)
-                  .length === 1
-                  ? "showing_count_result"
-                  : "showing_count_results",
-                {
-                  count: collections.filter(
-                    (e) => e.parentId === activeCollection?.id
-                  ).length,
+          {activeCollection?.description && (
+            <p>{activeCollection.description}</p>
+          )}
+
+          <Separator />
+
+          {collections.some((e) => e.parentId === activeCollection?.id) && (
+            <>
+              <PageHeader
+                icon="bi-folder"
+                title={t("collections")}
+                description={t(
+                  collections.filter((e) => e.parentId === activeCollection?.id)
+                    .length === 1
+                    ? "showing_count_result"
+                    : "showing_count_results",
+                  {
+                    count: collections.filter(
+                      (e) => e.parentId === activeCollection?.id
+                    ).length,
+                  }
+                )}
+                className="scale-90 w-fit"
+              />
+              <div className="grid 2xl:grid-cols-4 xl:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-5">
+                {collections
+                  .filter((e) => e.parentId === activeCollection?.id)
+                  .map((e) => (
+                    <CollectionCard key={e.id} collection={e} />
+                  ))}
+              </div>
+            </>
+          )}
+
+          <LinkListOptions
+            t={t}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            editMode={
+              permissions === true ||
+              permissions?.canUpdate ||
+              permissions?.canDelete
+                ? editMode
+                : undefined
+            }
+            setEditMode={
+              permissions === true ||
+              permissions?.canUpdate ||
+              permissions?.canDelete
+                ? setEditMode
+                : undefined
+            }
+            links={links}
+          >
+            {collections.some((e) => e.parentId === activeCollection?.id) ? (
+              <PageHeader
+                icon={"bi-link-45deg"}
+                title={t("links")}
+                description={
+                  activeCollection?._count?.links === 1
+                    ? t("showing_count_result", {
+                        count: activeCollection?._count?.links,
+                      })
+                    : t("showing_count_results", {
+                        count: activeCollection?._count?.links,
+                      })
                 }
-              )}
-              className="scale-90 w-fit"
-            />
-            <div className="grid 2xl:grid-cols-4 xl:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-5">
-              {collections
-                .filter((e) => e.parentId === activeCollection?.id)
-                .map((e) => (
-                  <CollectionCard key={e.id} collection={e} />
-                ))}
-            </div>
-          </>
-        )}
-
-        <LinkListOptions
-          t={t}
-          viewMode={viewMode}
-          setViewMode={setViewMode}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          editMode={
-            permissions === true ||
-            permissions?.canUpdate ||
-            permissions?.canDelete
-              ? editMode
-              : undefined
-          }
-          setEditMode={
-            permissions === true ||
-            permissions?.canUpdate ||
-            permissions?.canDelete
-              ? setEditMode
-              : undefined
-          }
-          links={links}
-        >
-          {collections.some((e) => e.parentId === activeCollection?.id) ? (
-            <PageHeader
-              icon={"bi-link-45deg"}
-              title={t("links")}
-              description={
-                activeCollection?._count?.links === 1
+                className="scale-90 w-fit"
+              />
+            ) : (
+              <p>
+                {activeCollection?._count?.links === 1
                   ? t("showing_count_result", {
                       count: activeCollection?._count?.links,
                     })
                   : t("showing_count_results", {
                       count: activeCollection?._count?.links,
-                    })
-              }
-              className="scale-90 w-fit"
-            />
-          ) : (
-            <p>
-              {activeCollection?._count?.links === 1
-                ? t("showing_count_result", {
-                    count: activeCollection?._count?.links,
-                  })
-                : t("showing_count_results", {
-                    count: activeCollection?._count?.links,
-                  })}
-            </p>
-          )}
-        </LinkListOptions>
+                    })}
+              </p>
+            )}
+          </LinkListOptions>
 
-        <Links
-          editMode={editMode}
-          links={links}
-          layout={viewMode}
-          placeholderCount={1}
-          useData={data}
-        />
-        {!data.isLoading && links && !links[0] && <NoLinksFound />}
-      </div>
-      {activeCollection && (
-        <>
-          {editCollectionModal && (
-            <EditCollectionModal
-              onClose={() => setEditCollectionModal(false)}
-              activeCollection={activeCollection}
-            />
-          )}
-          {editCollectionSharingModal && (
-            <EditCollectionSharingModal
-              onClose={() => setEditCollectionSharingModal(false)}
-              activeCollection={activeCollection}
-            />
-          )}
-          {newCollectionModal && (
-            <NewCollectionModal
-              onClose={() => setNewCollectionModal(false)}
-              parent={activeCollection}
-            />
-          )}
-          {deleteCollectionModal && (
-            <DeleteCollectionModal
-              onClose={() => setDeleteCollectionModal(false)}
-              activeCollection={activeCollection}
-            />
-          )}
-        </>
-      )}
-    </MainLayout>
+          <Links
+            editMode={editMode}
+            links={links}
+            layout={viewMode}
+            placeholderCount={1}
+            useData={data}
+          />
+          {!data.isLoading && links && !links[0] && <NoLinksFound />}
+        </div>
+        {activeCollection && (
+          <>
+            {editCollectionModal && (
+              <EditCollectionModal
+                onClose={() => setEditCollectionModal(false)}
+                activeCollection={activeCollection}
+              />
+            )}
+            {editCollectionSharingModal && (
+              <EditCollectionSharingModal
+                onClose={() => setEditCollectionSharingModal(false)}
+                activeCollection={activeCollection}
+              />
+            )}
+            {newCollectionModal && (
+              <NewCollectionModal
+                onClose={() => setNewCollectionModal(false)}
+                parent={activeCollection}
+              />
+            )}
+            {deleteCollectionModal && (
+              <DeleteCollectionModal
+                onClose={() => setDeleteCollectionModal(false)}
+                activeCollection={activeCollection}
+              />
+            )}
+          </>
+        )}
+      </MainLayout>
+    </DndContext>
   );
 }
 

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -95,11 +95,6 @@ export default function Dashboard() {
     DashboardSection[]
   >(user?.dashboardSections || []);
 
-  // State to track the collection being dropped on
-  const [droppingCollection, setDroppingCollection] = useState<string | null>(
-    null
-  );
-
   useEffect(() => {
     setDashboardSections(user?.dashboardSections || []);
   }, [user?.dashboardSections]);
@@ -188,25 +183,12 @@ export default function Dashboard() {
     setActiveLink(draggedLink || null);
   };
 
-  const handleDragOver = (event: DragOverEvent) => {
-    const { over } = event;
-    if (!over || !activeLink) return;
-
-    const targetId = over.id as string;
-    if (!targetId.includes("side-bar")) {
-      // when dragging over a collection on dashboard but not side bar, set the dropping collection
-      // this will be used to show link placeholder on target collection
-      setDroppingCollection(over.data.current?.collectionName as string);
-    }
-  };
   const handleDragOverCancel = () => {
     // Reset the dropping collection when dragging is cancelled
-    setDroppingCollection(null);
     setActiveLink(null);
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
-    setDroppingCollection(null);
     const { over, active } = event;
     if (!over || !activeLink) return;
 
@@ -310,7 +292,6 @@ export default function Dashboard() {
     <DndContext
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      onDragOver={handleDragOver}
       onDragCancel={handleDragOverCancel}
       modifiers={[restrictToWindowEdges, snapCenterToCursor]}
       sensors={sensors}
@@ -366,8 +347,6 @@ export default function Dashboard() {
                 numberOfPinnedLinks={numberOfPinnedLinks}
                 dashboardData={dashboardData}
                 setNewLinkModal={setNewLinkModal}
-                droppingCollection={droppingCollection}
-                activeLink={activeLink}
               />
             ))
           ) : (
@@ -415,8 +394,6 @@ type SectionProps = {
   dashboardData: any;
   collectionLinks: any[];
   setNewLinkModal: (value: boolean) => void;
-  droppingCollection?: string | null;
-  activeLink: LinkIncludingShortenedCollectionAndTags | null;
 };
 
 const Section = ({
@@ -431,8 +408,6 @@ const Section = ({
   dashboardData,
   collectionLinks,
   setNewLinkModal,
-  droppingCollection,
-  activeLink,
 }: SectionProps) => {
   switch (sectionData.type) {
     case DashboardSectionType.STATS:
@@ -544,10 +519,6 @@ const Section = ({
               <DashboardLinks
                 links={links.filter((e: any) => e.pinnedBy && e.pinnedBy[0])}
                 isLoading={dashboardData.isLoading}
-                isDropping={
-                  droppingCollection === "pinned-links" &&
-                  activeLink?.pinnedBy?.length === 0
-                }
               />
             ) : (
               <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200">
@@ -610,10 +581,6 @@ const Section = ({
                 type="collection"
                 links={collectionLinks}
                 isLoading={dashboardData.isLoading}
-                isDropping={
-                  droppingCollection === collection.name &&
-                  activeLink?.collection.name !== collection.name
-                }
               />
             ) : (
               <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200 min-h-72">

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -54,7 +54,6 @@ export default function Dashboard() {
   const pinLink = usePinLink();
 
   const [numberOfLinks, setNumberOfLinks] = useState(0);
-  const [linkCollectionExists, setLinkCollectionExists] = useState(false);
   const [activeLink, setActiveLink] =
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
 
@@ -124,7 +123,10 @@ export default function Dashboard() {
     if (!linkToRender) return null;
 
     return (
-      <div className="w-60 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg">
+      <div className="w-60 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
+        <span className="absolute z-50 top-3 left-2 w-6 h-6 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
+          <i className="bi-grip-vertical" />
+        </span>
         <Card link={linkToRender} />
       </div>
     );
@@ -174,12 +176,6 @@ export default function Dashboard() {
     const linkToMove = links.find((link: any) => link.id === activeLink.id);
 
     if (!linkToMove) return;
-
-    if (linkToMove.collection.id === activeLink.collectionId) {
-      setLinkCollectionExists(true);
-    } else {
-      setLinkCollectionExists(false);
-    }
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
@@ -222,7 +218,6 @@ export default function Dashboard() {
       );
     }
     setActiveLink(null);
-    setLinkCollectionExists(false);
   };
 
   return (

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -38,6 +38,9 @@ import {
   MouseSensor,
   TouchSensor,
   useSensors,
+  closestCenter,
+  pointerWithin,
+  rectIntersection,
 } from "@dnd-kit/core";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 import Droppable from "@/components/Droppable";
@@ -327,6 +330,7 @@ export default function Dashboard() {
       onDragCancel={handleDragOverCancel}
       modifiers={[restrictToWindowEdges]}
       sensors={sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
     >
       <MainLayout>
         {!!activeLink && (
@@ -644,3 +648,18 @@ const Section = ({
       return null;
   }
 };
+
+// Custom collision detection algorithm that first checks for pointer collisions
+// and then falls back to rectangle intersections
+function customCollisionDetectionAlgorithm(args: any) {
+  // First, let's see if there are any collisions with the pointer
+  const pointerCollisions = pointerWithin(args);
+
+  // Collision detection algorithms return an array of collisions
+  if (pointerCollisions.length > 0) {
+    return pointerCollisions;
+  }
+
+  // If there are no collisions with the pointer, return rectangle intersections
+  return rectIntersection(args);
+}

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -34,6 +34,10 @@ import {
   DragStartEvent,
   DragOverlay,
   DragOverEvent,
+  useSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensors,
 } from "@dnd-kit/core";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 import Droppable from "@/components/Droppable";
@@ -54,6 +58,22 @@ export default function Dashboard() {
   const { data: user } = useUser();
   const pinLink = usePinLink();
   const queryClient = useQueryClient();
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
 
   const [numberOfLinks, setNumberOfLinks] = useState(0);
   const [activeLink, setActiveLink] =
@@ -301,6 +321,7 @@ export default function Dashboard() {
       onDragOver={handleDragOver}
       onDragCancel={handleDragOverCancel}
       modifiers={[restrictToWindowEdges]}
+      sensors={sensors}
     >
       <MainLayout>
         {!!activeLink && (

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -20,7 +20,7 @@ import {
   DashboardSection,
   DashboardSectionType,
 } from "@linkwarden/prisma/client";
-import { DashboardLinks, Card } from "@/components/DashboardLinks";
+import { DashboardLinks } from "@/components/DashboardLinks";
 import {
   LinkIncludingShortenedCollectionAndTags,
   ViewMode,
@@ -39,12 +39,13 @@ import {
   TouchSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { restrictToWindowEdges } from "@dnd-kit/modifiers";
+import { restrictToWindowEdges, snapCenterToCursor } from "@dnd-kit/modifiers";
 import Droppable from "@/components/Droppable";
 import { useUpdateLink } from "@linkwarden/router/links";
 import usePinLink from "@/lib/client/pinLink";
 import { useQueryClient } from "@tanstack/react-query";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+import { LinkIcon } from "lucide-react";
 
 export default function Dashboard() {
   const { t } = useTranslation();
@@ -151,19 +152,6 @@ export default function Dashboard() {
   const [submitLoader, setSubmitLoader] = useState(false);
 
   // Function to render the dragged item
-  const renderDraggedItem = () => {
-    if (!activeLink) return null;
-
-    return (
-      <div className="w-60 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
-        <span className="absolute z-50 top-3 left-2 w-8 h-8 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
-          <i className="bi-grip-vertical text-xl" />
-        </span>
-        <Card link={activeLink} />
-      </div>
-    );
-  };
-
   const submitSurvey = async (referer: string, other?: string) => {
     if (submitLoader) return;
 
@@ -324,7 +312,7 @@ export default function Dashboard() {
       onDragEnd={handleDragEnd}
       onDragOver={handleDragOver}
       onDragCancel={handleDragOverCancel}
-      modifiers={[restrictToWindowEdges]}
+      modifiers={[restrictToWindowEdges, snapCenterToCursor]}
       sensors={sensors}
       collisionDetection={customCollisionDetectionAlgorithm}
     >
@@ -337,7 +325,9 @@ export default function Dashboard() {
               pointerEvents: "none",
             }}
           >
-            {renderDraggedItem()}
+            <div className="size-20 rounded-md bg-base-100/80 flex items-center justify-center">
+              <LinkIcon />
+            </div>
           </DragOverlay>
         )}
         <div className="p-5 flex flex-col gap-4 h-full">
@@ -583,60 +573,59 @@ const Section = ({
               collectionName: collection.name,
               ownerId: collection.ownerId,
             }}
+            className="flex flex-col gap-4"
           >
-            <div>
-              <div className="flex justify-between items-center">
-                <div className="flex gap-2 items-center">
-                  <div className={clsx("flex items-center gap-3")}>
-                    {collection.icon ? (
-                      <Icon
-                        icon={collection.icon}
-                        color={collection.color || "#0ea5e9"}
-                        className="text-2xl"
-                      />
-                    ) : (
-                      <i
-                        className={`bi-folder-fill text-primary text-2xl drop-shadow`}
-                        style={{ color: collection.color || "#0ea5e9" }}
-                      ></i>
-                    )}
-                    <div>
-                      <p className="text-2xl capitalize font-thin">
-                        {collection.name}
-                      </p>
-                    </div>
+            <div className="flex justify-between items-center">
+              <div className="flex gap-2 items-center">
+                <div className={clsx("flex items-center gap-3")}>
+                  {collection.icon ? (
+                    <Icon
+                      icon={collection.icon}
+                      color={collection.color || "#0ea5e9"}
+                      className="text-2xl"
+                    />
+                  ) : (
+                    <i
+                      className={`bi-folder-fill text-primary text-2xl drop-shadow`}
+                      style={{ color: collection.color || "#0ea5e9" }}
+                    ></i>
+                  )}
+                  <div>
+                    <p className="text-2xl capitalize font-thin">
+                      {collection.name}
+                    </p>
                   </div>
                 </div>
-                <Link
-                  href={`/collections/${collection.id}`}
-                  className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer whitespace-nowrap"
-                >
-                  {t("view_all")}
-                  <i className="bi-chevron-right text-sm"></i>
-                </Link>
               </div>
-              {dashboardData.isLoading || collectionLinks?.length > 0 ? (
-                <DashboardLinks
-                  type="collection"
-                  links={collectionLinks}
-                  isLoading={dashboardData.isLoading}
-                  isDropping={
-                    droppingCollection === collection.name &&
-                    activeLink?.collection.name !== collection.name
-                  }
-                />
-              ) : (
-                <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200 min-h-72">
-                  <i className="bi-folder mx-auto text-6xl text-primary"></i>
-                  <p className="text-center text-xl">
-                    {t("no_link_in_collection")}
-                  </p>
-                  <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
-                    {t("no_link_in_collection_desc")}
-                  </p>
-                </div>
-              )}
+              <Link
+                href={`/collections/${collection.id}`}
+                className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer whitespace-nowrap"
+              >
+                {t("view_all")}
+                <i className="bi-chevron-right text-sm"></i>
+              </Link>
             </div>
+            {dashboardData.isLoading || collectionLinks?.length > 0 ? (
+              <DashboardLinks
+                type="collection"
+                links={collectionLinks}
+                isLoading={dashboardData.isLoading}
+                isDropping={
+                  droppingCollection === collection.name &&
+                  activeLink?.collection.name !== collection.name
+                }
+              />
+            ) : (
+              <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200 min-h-72">
+                <i className="bi-folder mx-auto text-6xl text-primary"></i>
+                <p className="text-center text-xl">
+                  {t("no_link_in_collection")}
+                </p>
+                <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
+                  {t("no_link_in_collection_desc")}
+                </p>
+              </div>
+            )}
           </Droppable>
         )
       );

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -204,7 +204,12 @@ export default function Dashboard() {
 
     if (!linkToMove) return;
 
-    setDroppingCollection(over.data.current?.collectionName as string);
+    const targetId = over.id as string;
+    if (!targetId.includes("side-bar")) {
+      // when dragging over a collection on dashboard but not side bar, set the dropping collection
+      // this will be used to show link placeholder on target collection
+      setDroppingCollection(over.data.current?.collectionName as string);
+    }
   };
   const handleDragOverCancel = () => {
     // Reset the dropping collection when dragging is cancelled
@@ -572,7 +577,7 @@ const Section = ({
       return (
         collection?.id && (
           <Droppable
-            id={collection.id}
+            id={`dashboard-${collection.id}`}
             data={{
               collectionId: collection.id,
               collectionName: collection.name,

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -126,8 +126,8 @@ export default function Dashboard() {
 
     return (
       <div className="w-60 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
-        <span className="absolute z-50 top-3 left-2 w-6 h-6 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
-          <i className="bi-grip-vertical" />
+        <span className="absolute z-50 top-3 left-2 w-8 h-8 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
+          <i className="bi-grip-vertical text-xl" />
         </span>
         <Card link={linkToRender} />
       </div>
@@ -246,7 +246,7 @@ export default function Dashboard() {
         });
       }
 
-      const load = toast.loading(t("moving"));
+      const load = toast.loading(t("updating"));
       await updateLink.mutateAsync(updatedLink, {
         onSettled: (_, error) => {
           toast.dismiss(load);
@@ -379,6 +379,7 @@ const Section = ({
   collectionLinks,
   setNewLinkModal,
 }: SectionProps) => {
+  console.log("links", links);
   switch (sectionData.type) {
     case DashboardSectionType.STATS:
       return (

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -181,13 +181,15 @@ export default function Dashboard() {
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
-    const { over } = event;
+    const { over, active } = event;
     if (!over || !activeLink) return;
 
     const targetSectionId = over.id as string;
     const collectionId = over.data.current?.collectionId as number;
     const ownerId = over.data.current?.ownerId as string;
     const collectionName = over.data.current?.collectionName as string;
+
+    const isFromRecentSection = active.data.current?.dashboardType === "recent";
 
     // Find the link in the current data
     const linkToMove = links.find((link: any) => link.id === activeLink.id);
@@ -259,6 +261,9 @@ export default function Dashboard() {
           }
         },
       });
+    } else if (isFromRecentSection) {
+      // show error if link is dragged from recent section to the target collection which it already belongs to
+      toast.error(t("link_already_in_collection"));
     }
   };
 
@@ -379,7 +384,6 @@ const Section = ({
   collectionLinks,
   setNewLinkModal,
 }: SectionProps) => {
-  console.log("links", links);
   switch (sectionData.type) {
     case DashboardSectionType.STATS:
       return (
@@ -506,9 +510,9 @@ const Section = ({
           <Droppable
             id={collection.id}
             data={{
-              collectionId: collection?.id,
-              collectionName: collection?.name,
-              ownerId: collection?.ownerId,
+              collectionId: collection.id,
+              collectionName: collection.name,
+              ownerId: collection.ownerId,
             }}
           >
             <div>

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -514,6 +514,10 @@ const Section = ({
               <DashboardLinks
                 links={links.filter((e: any) => e.pinnedBy && e.pinnedBy[0])}
                 isLoading={dashboardData.isLoading}
+                isDropping={
+                  droppingCollection === "pinned-links" &&
+                  activeLink?.pinnedBy?.length === 0
+                }
               />
             ) : (
               <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200">

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -440,79 +440,73 @@ const Section = ({
     case DashboardSectionType.RECENT_LINKS:
       return (
         <>
-          <div>
-            <div className="flex justify-between items-center">
-              <div className="flex gap-2 items-center">
-                <PageHeader
-                  icon={"bi-clock-history"}
-                  title={t("recent_links")}
-                />
-              </div>
-              <Link
-                href="/links"
-                className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer"
-              >
-                {t("view_all")}
-                <i className="bi-chevron-right text-sm"></i>
-              </Link>
+          <div className="flex justify-between items-center">
+            <div className="flex gap-2 items-center">
+              <PageHeader icon={"bi-clock-history"} title={t("recent_links")} />
             </div>
-
-            {dashboardData.isLoading ||
-            (links && links[0] && !dashboardData.isLoading) ? (
-              <DashboardLinks
-                type="recent"
-                links={links}
-                isLoading={dashboardData.isLoading}
-              />
-            ) : (
-              <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200">
-                <p className="text-center text-xl">
-                  {t("view_added_links_here")}
-                </p>
-                <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm mt-2">
-                  {t("view_added_links_here_desc")}
-                </p>
-
-                <div className="text-center w-full mt-4 flex flex-wrap gap-4 justify-center">
-                  <Button
-                    onClick={() => {
-                      setNewLinkModal(true);
-                    }}
-                    variant="accent"
-                  >
-                    <i className="bi-plus-lg text-xl"></i>
-                    {t("add_link")}
-                  </Button>
-
-                  <ImportDropdown />
-                </div>
-              </div>
-            )}
+            <Link
+              href="/links"
+              className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer"
+            >
+              {t("view_all")}
+              <i className="bi-chevron-right text-sm"></i>
+            </Link>
           </div>
+
+          {dashboardData.isLoading ||
+          (links && links[0] && !dashboardData.isLoading) ? (
+            <DashboardLinks
+              type="recent"
+              links={links}
+              isLoading={dashboardData.isLoading}
+            />
+          ) : (
+            <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200">
+              <p className="text-center text-xl">
+                {t("view_added_links_here")}
+              </p>
+              <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm mt-2">
+                {t("view_added_links_here_desc")}
+              </p>
+
+              <div className="text-center w-full mt-4 flex flex-wrap gap-4 justify-center">
+                <Button
+                  onClick={() => {
+                    setNewLinkModal(true);
+                  }}
+                  variant="accent"
+                >
+                  <i className="bi-plus-lg text-xl"></i>
+                  {t("add_link")}
+                </Button>
+
+                <ImportDropdown />
+              </div>
+            </div>
+          )}
         </>
       );
     case DashboardSectionType.PINNED_LINKS:
       return (
-        <Droppable
-          id="pinned-links-section"
-          data={{
-            collectionName: "pinned-links",
-          }}
-        >
-          <div>
-            <div className="flex justify-between items-center">
-              <div className="flex gap-2 items-center">
-                <PageHeader icon={"bi-pin-angle"} title={t("pinned_links")} />
-              </div>
-              <Link
-                href="/links/pinned"
-                className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer"
-              >
-                {t("view_all")}
-                <i className="bi-chevron-right text-sm "></i>
-              </Link>
+        <>
+          <div className="flex justify-between items-center">
+            <div className="flex gap-2 items-center">
+              <PageHeader icon={"bi-pin-angle"} title={t("pinned_links")} />
             </div>
-
+            <Link
+              href="/links/pinned"
+              className="flex items-center text-sm text-black/75 dark:text-white/75 gap-2 cursor-pointer"
+            >
+              {t("view_all")}
+              <i className="bi-chevron-right text-sm "></i>
+            </Link>
+          </div>
+          <Droppable
+            id="pinned-links-section"
+            data={{
+              collectionName: "pinned-links",
+            }}
+          >
             {dashboardData.isLoading ||
             links?.some((e: any) => e.pinnedBy && e.pinnedBy[0]) ? (
               <DashboardLinks
@@ -530,21 +524,13 @@ const Section = ({
                 </p>
               </div>
             )}
-          </div>
-        </Droppable>
+          </Droppable>
+        </>
       );
     case DashboardSectionType.COLLECTION:
       return (
         collection?.id && (
-          <Droppable
-            id={`dashboard-${collection.id}`}
-            data={{
-              collectionId: collection.id,
-              collectionName: collection.name,
-              ownerId: collection.ownerId,
-            }}
-            className="flex flex-col gap-4"
-          >
+          <>
             <div className="flex justify-between items-center">
               <div className="flex gap-2 items-center">
                 <div className={clsx("flex items-center gap-3")}>
@@ -575,24 +561,33 @@ const Section = ({
                 <i className="bi-chevron-right text-sm"></i>
               </Link>
             </div>
-            {dashboardData.isLoading || collectionLinks?.length > 0 ? (
-              <DashboardLinks
-                type="collection"
-                links={collectionLinks}
-                isLoading={dashboardData.isLoading}
-              />
-            ) : (
-              <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200 min-h-72">
-                <i className="bi-folder mx-auto text-6xl text-primary"></i>
-                <p className="text-center text-xl">
-                  {t("no_link_in_collection")}
-                </p>
-                <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
-                  {t("no_link_in_collection_desc")}
-                </p>
-              </div>
-            )}
-          </Droppable>
+            <Droppable
+              id={`dashboard-${collection.id}`}
+              data={{
+                collectionId: collection.id,
+                collectionName: collection.name,
+                ownerId: collection.ownerId,
+              }}
+            >
+              {dashboardData.isLoading || collectionLinks?.length > 0 ? (
+                <DashboardLinks
+                  type="collection"
+                  links={collectionLinks}
+                  isLoading={dashboardData.isLoading}
+                />
+              ) : (
+                <div className="flex flex-col gap-2 justify-center h-full border border-solid border-neutral-content w-full mx-auto p-10 rounded-xl bg-base-200 bg-gradient-to-tr from-neutral-content/70 to-50% to-base-200 min-h-72">
+                  <i className="bi-folder mx-auto text-6xl text-primary"></i>
+                  <p className="text-center text-xl">
+                    {t("no_link_in_collection")}
+                  </p>
+                  <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
+                    {t("no_link_in_collection_desc")}
+                  </p>
+                </div>
+              )}
+            </Droppable>
+          </>
         )
       );
     default:

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -212,9 +212,23 @@ export default function Dashboard() {
     // Immediately hide the drag overlay
     setActiveLink(null);
 
-    // Handle pinning/unpinning the link
+    // Handle pinning the link
     if (targetSectionId === "pinned-links-section") {
       if (Array.isArray(linkToMove.pinnedBy) && !linkToMove.pinnedBy.length) {
+        // optimistically update the link's pinned state
+        const updatedLink = {
+          ...linkToMove,
+          pinnedBy: [user?.id],
+        };
+        queryClient.setQueryData(["dashboardData"], (oldData: any) => {
+          if (!oldData?.links) return oldData;
+          return {
+            ...oldData,
+            links: oldData.links.map((link: any) =>
+              link.id === updatedLink.id ? updatedLink : link
+            ),
+          };
+        });
         pinLink(linkToMove);
       }
       // Handle moving the link to a different collection

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -38,15 +38,13 @@ import {
   MouseSensor,
   TouchSensor,
   useSensors,
-  closestCenter,
-  pointerWithin,
-  rectIntersection,
 } from "@dnd-kit/core";
 import { restrictToWindowEdges } from "@dnd-kit/modifiers";
 import Droppable from "@/components/Droppable";
 import { useUpdateLink } from "@linkwarden/router/links";
 import usePinLink from "@/lib/client/pinLink";
 import { useQueryClient } from "@tanstack/react-query";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 
 export default function Dashboard() {
   const { t } = useTranslation();
@@ -646,18 +644,3 @@ const Section = ({
       return null;
   }
 };
-
-// Custom collision detection algorithm that first checks for pointer collisions
-// and then falls back to rectangle intersections
-function customCollisionDetectionAlgorithm(args: any) {
-  // First, let's see if there are any collisions with the pointer
-  const pointerCollisions = pointerWithin(args);
-
-  // Collision detection algorithms return an array of collisions
-  if (pointerCollisions.length > 0) {
-    return pointerCollisions;
-  }
-
-  // If there are no collisions with the pointer, return rectangle intersections
-  return rectIntersection(args);
-}

--- a/apps/web/pages/dashboard.tsx
+++ b/apps/web/pages/dashboard.tsx
@@ -33,7 +33,6 @@ import {
   DragEndEvent,
   DragStartEvent,
   DragOverlay,
-  DragOverEvent,
   useSensor,
   MouseSensor,
   TouchSensor,
@@ -45,7 +44,7 @@ import { useUpdateLink } from "@linkwarden/router/links";
 import usePinLink from "@/lib/client/pinLink";
 import { useQueryClient } from "@tanstack/react-query";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
-import { LinkIcon } from "lucide-react";
+import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
 
 export default function Dashboard() {
   const { t } = useTranslation();
@@ -306,8 +305,8 @@ export default function Dashboard() {
               pointerEvents: "none",
             }}
           >
-            <div className="size-20 rounded-md bg-base-100/80 flex items-center justify-center">
-              <LinkIcon />
+            <div className="w-fit h-fit">
+              <LinkIcon link={activeLink} />
             </div>
           </DragOverlay>
         )}

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -25,9 +25,9 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { useQueryClient } from "@tanstack/react-query";
-import LinkCard from "@/components/LinkViews/LinkComponents/LinkCard";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
+import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
 
 export default function Index() {
   const [activeLink, setActiveLink] =
@@ -62,21 +62,6 @@ export default function Index() {
     },
   });
 
-  const renderDraggedItem = () => {
-    if (!activeLink) return null;
-
-    return (
-      <div className="w-80 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
-        <span className="absolute z-50 top-3 left-2 w-8 h-8 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
-          <i className="bi-grip-vertical text-xl" />
-        </span>
-        {viewMode === ViewMode.Card && (
-          <LinkCard link={activeLink} columns={2} />
-        )}
-      </div>
-    );
-  };
-
   const sensors = useSensors(mouseSensor, touchSensor);
 
   const router = useRouter();
@@ -108,6 +93,12 @@ export default function Index() {
 
     // Immediately hide the drag overlay
     setActiveLink(null);
+
+    // if the link dropped over the same collection, toast
+    if (activeLink.collection.id === collectionId) {
+      toast.error(t("link_already_in_collection"));
+      return;
+    }
 
     // Handle moving the link to a different collection
     if (activeLink.collection.id !== collectionId) {
@@ -146,9 +137,13 @@ export default function Index() {
       modifiers={[snapCenterToCursor]}
     >
       <MainLayout>
-        <DragOverlay className="z-50 pointer-events-none">
-          {renderDraggedItem()}
-        </DragOverlay>
+        {!!activeLink && (
+          <DragOverlay className="z-50 pointer-events-none">
+            <div className="w-fit h-fit">
+              <LinkIcon link={activeLink} />
+            </div>
+          </DragOverlay>
+        )}
         <div className="p-5 flex flex-col gap-5 w-full h-full">
           <LinkListOptions
             t={t}

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -26,8 +26,8 @@ import {
 } from "@dnd-kit/core";
 import { useQueryClient } from "@tanstack/react-query";
 import LinkCard from "@/components/LinkViews/LinkComponents/LinkCard";
-import useLocalSettingsStore from "@/store/localSettings";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+import { snapCenterToCursor } from "@dnd-kit/modifiers";
 
 export default function Index() {
   const [activeLink, setActiveLink] =
@@ -61,18 +61,17 @@ export default function Index() {
       tolerance: 5,
     },
   });
-  const settings = useLocalSettingsStore((state) => state.settings);
 
   const renderDraggedItem = () => {
     if (!activeLink) return null;
 
     return (
-      <div className="border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
+      <div className="w-80 border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
         <span className="absolute z-50 top-3 left-2 w-8 h-8 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
           <i className="bi-grip-vertical text-xl" />
         </span>
         {viewMode === ViewMode.Card && (
-          <LinkCard link={activeLink} columns={settings.columns} />
+          <LinkCard link={activeLink} columns={2} />
         )}
       </div>
     );
@@ -144,14 +143,10 @@ export default function Index() {
       onDragCancel={handleDragOverCancel}
       sensors={sensors}
       collisionDetection={customCollisionDetectionAlgorithm}
+      modifiers={[snapCenterToCursor]}
     >
       <MainLayout>
-        <DragOverlay
-          style={{
-            zIndex: 100,
-            pointerEvents: "none",
-          }}
-        >
+        <DragOverlay className="z-50 pointer-events-none">
           {renderDraggedItem()}
         </DragOverlay>
         <div className="p-5 flex flex-col gap-5 w-full h-full">

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -11,22 +11,9 @@ import { useRouter } from "next/router";
 import LinkListOptions from "@/components/LinkListOptions";
 import getServerSideProps from "@/lib/client/getServerSideProps";
 import { useTranslation } from "next-i18next";
-import { toast } from "react-hot-toast";
 import Links from "@/components/LinkViews/Links";
 import clsx from "clsx";
-import {
-  DndContext,
-  DragEndEvent,
-  DragOverlay,
-  DragStartEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import { customCollisionDetectionAlgorithm } from "@/lib/utils";
-import { snapCenterToCursor } from "@dnd-kit/modifiers";
-import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
+import DragNDrop from "@/components/DragNDrop";
 
 export default function Index() {
   const [activeLink, setActiveLink] =
@@ -44,24 +31,6 @@ export default function Index() {
     sort: sortBy,
   });
 
-  const updateLink = useUpdateLink();
-
-  const mouseSensor = useSensor(MouseSensor, {
-    // Require the mouse to move by 10 pixels before activating
-    activationConstraint: {
-      distance: 10,
-    },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    // Press delay of 250ms, with tolerance of 5px of movement
-    activationConstraint: {
-      delay: 200,
-      tolerance: 5,
-    },
-  });
-
-  const sensors = useSensors(mouseSensor, touchSensor);
-
   const router = useRouter();
 
   const [editMode, setEditMode] = useState(false);
@@ -70,73 +39,13 @@ export default function Index() {
     if (editMode) return setEditMode(false);
   }, [router]);
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const draggedLink = links.find(
-      (link: any) => link.id === event.active.data.current?.linkId
-    );
-    setActiveLink(draggedLink || null);
-  };
-
-  const handleDragOverCancel = () => {
-    setActiveLink(null);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { over } = event;
-    if (!over || !activeLink) return;
-
-    const collectionId = over.data.current?.collectionId as number;
-    const collectionName = over.data.current?.collectionName as string;
-    const ownerId = over.data.current?.ownerId as number;
-
-    // Immediately hide the drag overlay
-    setActiveLink(null);
-
-    // if the link dropped over the same collection, toast
-    if (activeLink.collection.id === collectionId) {
-      toast.error(t("link_already_in_collection"));
-      return;
-    }
-
-    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
-      ...activeLink,
-      collection: {
-        id: collectionId,
-        name: collectionName,
-        ownerId,
-      },
-    };
-
-    const load = toast.loading(t("updating"));
-    await updateLink.mutateAsync(updatedLink, {
-      onSettled: (_, error) => {
-        toast.dismiss(load);
-        if (error) {
-          toast.error(error.message);
-        } else {
-          toast.success(t("updated"));
-        }
-      },
-    });
-  };
-
   return (
-    <DndContext
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragOverCancel}
-      sensors={sensors}
-      collisionDetection={customCollisionDetectionAlgorithm}
-      modifiers={[snapCenterToCursor]}
+    <DragNDrop
+      links={links}
+      activeLink={activeLink}
+      setActiveLink={setActiveLink}
     >
       <MainLayout>
-        {!!activeLink && (
-          <DragOverlay className="z-50 pointer-events-none">
-            <div className="w-fit h-fit">
-              <LinkIcon link={activeLink} />
-            </div>
-          </DragOverlay>
-        )}
         <div className="p-5 flex flex-col gap-5 w-full h-full">
           <LinkListOptions
             t={t}
@@ -173,7 +82,7 @@ export default function Index() {
           />
         </div>
       </MainLayout>
-    </DndContext>
+    </DragNDrop>
   );
 }
 

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -1,17 +1,37 @@
 import NoLinksFound from "@/components/NoLinksFound";
-import { useLinks } from "@linkwarden/router/links";
+import { useLinks, useUpdateLink } from "@linkwarden/router/links";
 import MainLayout from "@/layouts/MainLayout";
 import React, { useEffect, useState } from "react";
-import PageHeader from "@/components/PageHeader";
-import { Sort, ViewMode } from "@linkwarden/types";
+import {
+  LinkIncludingShortenedCollectionAndTags,
+  Sort,
+  ViewMode,
+} from "@linkwarden/types";
 import { useRouter } from "next/router";
 import LinkListOptions from "@/components/LinkListOptions";
 import getServerSideProps from "@/lib/client/getServerSideProps";
 import { useTranslation } from "next-i18next";
+import { toast } from "react-hot-toast";
 import Links from "@/components/LinkViews/Links";
 import clsx from "clsx";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
+import LinkCard from "@/components/LinkViews/LinkComponents/LinkCard";
+import useLocalSettingsStore from "@/store/localSettings";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 
 export default function Index() {
+  const [activeLink, setActiveLink] =
+    useState<LinkIncludingShortenedCollectionAndTags | null>(null);
   const { t } = useTranslation();
 
   const [viewMode, setViewMode] = useState<ViewMode>(
@@ -25,6 +45,41 @@ export default function Index() {
     sort: sortBy,
   });
 
+  const updateLink = useUpdateLink();
+  const queryClient = useQueryClient();
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+  const settings = useLocalSettingsStore((state) => state.settings);
+
+  const renderDraggedItem = () => {
+    if (!activeLink) return null;
+
+    return (
+      <div className="border border-solid border-neutral-content bg-base-200 rounded-xl shadow-lg relative">
+        <span className="absolute z-50 top-3 left-2 w-8 h-8 p-1 rounded bg-base-100/80 inline-flex items-center justify-center">
+          <i className="bi-grip-vertical text-xl" />
+        </span>
+        {viewMode === ViewMode.Card && (
+          <LinkCard link={activeLink} columns={settings.columns} />
+        )}
+      </div>
+    );
+  };
+
+  const sensors = useSensors(mouseSensor, touchSensor);
+
   const router = useRouter();
 
   const [editMode, setEditMode] = useState(false);
@@ -33,42 +88,109 @@ export default function Index() {
     if (editMode) return setEditMode(false);
   }, [router]);
 
-  return (
-    <MainLayout>
-      <div className="p-5 flex flex-col gap-5 w-full h-full">
-        <LinkListOptions
-          t={t}
-          viewMode={viewMode}
-          setViewMode={setViewMode}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          editMode={editMode}
-          setEditMode={setEditMode}
-          links={links}
-        >
-          <div className={clsx("flex items-center gap-3")}>
-            <i
-              className={`bi-link-45deg text-primary text-3xl drop-shadow`}
-            ></i>
-            <div>
-              <p className="text-2xl capitalize font-thin">{t("all_links")}</p>
-              <p className="text-xs sm:text-sm">{t("all_links_desc")}</p>
-            </div>
-          </div>
-        </LinkListOptions>
+  const handleDragStart = (event: DragStartEvent) => {
+    const draggedLink = links.find(
+      (link: any) => link.id === event.active.data.current?.linkId
+    );
+    setActiveLink(draggedLink || null);
+  };
 
-        {!data.isLoading && links && !links[0] && (
-          <NoLinksFound text={t("you_have_not_added_any_links")} />
-        )}
-        <Links
-          editMode={editMode}
-          links={links}
-          layout={viewMode}
-          placeholderCount={1}
-          useData={data}
-        />
-      </div>
-    </MainLayout>
+  const handleDragOverCancel = () => {
+    setActiveLink(null);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { over } = event;
+    if (!over || !activeLink) return;
+
+    const collectionId = over.data.current?.collectionId as number;
+    const collectionName = over.data.current?.collectionName as string;
+    const ownerId = over.data.current?.ownerId as number;
+
+    // Immediately hide the drag overlay
+    setActiveLink(null);
+
+    // Handle moving the link to a different collection
+    if (activeLink.collection.id !== collectionId) {
+      const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+        ...activeLink,
+        collection: {
+          id: collectionId,
+          name: collectionName,
+          ownerId,
+        },
+      };
+
+      const load = toast.loading(t("updating"));
+      await updateLink.mutateAsync(updatedLink, {
+        onSettled: (_, error) => {
+          toast.dismiss(load);
+          if (error) {
+            // If there's an error, invalidate queries to restore the original state
+            queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
+            toast.error(error.message);
+          } else {
+            toast.success(t("updated"));
+          }
+        },
+      });
+    }
+  };
+
+  return (
+    <DndContext
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragOverCancel}
+      sensors={sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
+    >
+      <MainLayout>
+        <DragOverlay
+          style={{
+            zIndex: 100,
+            pointerEvents: "none",
+          }}
+        >
+          {renderDraggedItem()}
+        </DragOverlay>
+        <div className="p-5 flex flex-col gap-5 w-full h-full">
+          <LinkListOptions
+            t={t}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            editMode={editMode}
+            setEditMode={setEditMode}
+            links={links}
+          >
+            <div className={clsx("flex items-center gap-3")}>
+              <i
+                className={`bi-link-45deg text-primary text-3xl drop-shadow`}
+              ></i>
+              <div>
+                <p className="text-2xl capitalize font-thin">
+                  {t("all_links")}
+                </p>
+                <p className="text-xs sm:text-sm">{t("all_links_desc")}</p>
+              </div>
+            </div>
+          </LinkListOptions>
+
+          {!data.isLoading && links && !links[0] && (
+            <NoLinksFound text={t("you_have_not_added_any_links")} />
+          )}
+          <Links
+            editMode={editMode}
+            links={links}
+            layout={viewMode}
+            placeholderCount={1}
+            useData={data}
+          />
+        </div>
+      </MainLayout>
+    </DndContext>
   );
 }
 

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -24,7 +24,6 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { useQueryClient } from "@tanstack/react-query";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
 import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
@@ -46,7 +45,6 @@ export default function Index() {
   });
 
   const updateLink = useUpdateLink();
-  const queryClient = useQueryClient();
 
   const mouseSensor = useSensor(MouseSensor, {
     // Require the mouse to move by 10 pixels before activating
@@ -114,8 +112,6 @@ export default function Index() {
       onSettled: (_, error) => {
         toast.dismiss(load);
         if (error) {
-          // If there's an error, invalidate queries to restore the original state
-          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
           toast.error(error.message);
         } else {
           toast.success(t("updated"));

--- a/apps/web/pages/links/index.tsx
+++ b/apps/web/pages/links/index.tsx
@@ -100,31 +100,28 @@ export default function Index() {
       return;
     }
 
-    // Handle moving the link to a different collection
-    if (activeLink.collection.id !== collectionId) {
-      const updatedLink: LinkIncludingShortenedCollectionAndTags = {
-        ...activeLink,
-        collection: {
-          id: collectionId,
-          name: collectionName,
-          ownerId,
-        },
-      };
+    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+      ...activeLink,
+      collection: {
+        id: collectionId,
+        name: collectionName,
+        ownerId,
+      },
+    };
 
-      const load = toast.loading(t("updating"));
-      await updateLink.mutateAsync(updatedLink, {
-        onSettled: (_, error) => {
-          toast.dismiss(load);
-          if (error) {
-            // If there's an error, invalidate queries to restore the original state
-            queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
-            toast.error(error.message);
-          } else {
-            toast.success(t("updated"));
-          }
-        },
-      });
-    }
+    const load = toast.loading(t("updating"));
+    await updateLink.mutateAsync(updatedLink, {
+      onSettled: (_, error) => {
+        toast.dismiss(load);
+        if (error) {
+          // If there's an error, invalidate queries to restore the original state
+          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
+          toast.error(error.message);
+        } else {
+          toast.success(t("updated"));
+        }
+      },
+    });
   };
 
   return (

--- a/apps/web/pages/links/pinned.tsx
+++ b/apps/web/pages/links/pinned.tsx
@@ -9,22 +9,9 @@ import {
 import { useTranslation } from "next-i18next";
 import getServerSideProps from "@/lib/client/getServerSideProps";
 import LinkListOptions from "@/components/LinkListOptions";
-import { useLinks, useUpdateLink } from "@linkwarden/router/links";
+import { useLinks } from "@linkwarden/router/links";
 import Links from "@/components/LinkViews/Links";
-import {
-  DndContext,
-  DragEndEvent,
-  DragOverlay,
-  DragStartEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import toast from "react-hot-toast";
-import { snapCenterToCursor } from "@dnd-kit/modifiers";
-import { customCollisionDetectionAlgorithm } from "@/lib/utils";
-import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
+import DragNDrop from "@/components/DragNDrop";
 
 export default function PinnedLinks() {
   const { t } = useTranslation();
@@ -41,94 +28,17 @@ export default function PinnedLinks() {
     pinnedOnly: true,
   });
 
-  const mouseSensor = useSensor(MouseSensor, {
-    // Require the mouse to move by 10 pixels before activating
-    activationConstraint: {
-      distance: 10,
-    },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    // Press delay of 250ms, with tolerance of 5px of movement
-    activationConstraint: {
-      delay: 200,
-      tolerance: 5,
-    },
-  });
-
-  const sensors = useSensors(mouseSensor, touchSensor);
-
-  const updateLink = useUpdateLink();
   const [activeLink, setActiveLink] =
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
   const [editMode, setEditMode] = useState(false);
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const draggedLink = links.find(
-      (link: any) => link.id === event.active.data.current?.linkId
-    );
-    setActiveLink(draggedLink || null);
-  };
-
-  const handleDragOverCancel = () => {
-    setActiveLink(null);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { over } = event;
-    if (!over || !activeLink) return;
-
-    const collectionId = over.data.current?.collectionId as number;
-    const collectionName = over.data.current?.collectionName as string;
-    const ownerId = over.data.current?.ownerId as number;
-
-    // Immediately hide the drag overlay
-    setActiveLink(null);
-
-    // if the link dropped over the same collection, toast
-    if (activeLink.collection.id === collectionId) {
-      toast.error(t("link_already_in_collection"));
-      return;
-    }
-
-    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
-      ...activeLink,
-      collection: {
-        id: collectionId,
-        name: collectionName,
-        ownerId,
-      },
-    };
-
-    const load = toast.loading(t("updating"));
-    await updateLink.mutateAsync(updatedLink, {
-      onSettled: (_, error) => {
-        toast.dismiss(load);
-        if (error) {
-          toast.error(error.message);
-        } else {
-          toast.success(t("updated"));
-        }
-      },
-    });
-  };
-
   return (
-    <DndContext
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragOverCancel}
-      sensors={sensors}
-      collisionDetection={customCollisionDetectionAlgorithm}
-      modifiers={[snapCenterToCursor]}
+    <DragNDrop
+      links={links}
+      activeLink={activeLink}
+      setActiveLink={setActiveLink}
     >
       <MainLayout>
-        {!!activeLink && (
-          <DragOverlay className="z-50 pointer-events-none">
-            <div className="w-fit h-fit">
-              <LinkIcon link={activeLink} />
-            </div>
-          </DragOverlay>
-        )}
         <div className="p-5 flex flex-col gap-5 w-full h-full">
           <LinkListOptions
             t={t}
@@ -177,7 +87,7 @@ export default function PinnedLinks() {
           />
         </div>
       </MainLayout>
-    </DndContext>
+    </DragNDrop>
   );
 }
 

--- a/apps/web/pages/links/pinned.tsx
+++ b/apps/web/pages/links/pinned.tsx
@@ -1,13 +1,31 @@
 import MainLayout from "@/layouts/MainLayout";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import PageHeader from "@/components/PageHeader";
-import { Sort, ViewMode } from "@linkwarden/types";
-import { useRouter } from "next/router";
+import {
+  LinkIncludingShortenedCollectionAndTags,
+  Sort,
+  ViewMode,
+} from "@linkwarden/types";
 import { useTranslation } from "next-i18next";
 import getServerSideProps from "@/lib/client/getServerSideProps";
 import LinkListOptions from "@/components/LinkListOptions";
-import { useLinks } from "@linkwarden/router/links";
+import { useLinks, useUpdateLink } from "@linkwarden/router/links";
 import Links from "@/components/LinkViews/Links";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import toast from "react-hot-toast";
+import { useQueryClient } from "@tanstack/react-query";
+import { snapCenterToCursor } from "@dnd-kit/modifiers";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
 
 export default function PinnedLinks() {
   const { t } = useTranslation();
@@ -24,59 +42,146 @@ export default function PinnedLinks() {
     pinnedOnly: true,
   });
 
-  const router = useRouter();
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
+
+  const queryClient = useQueryClient();
+  const updateLink = useUpdateLink();
+  const [activeLink, setActiveLink] =
+    useState<LinkIncludingShortenedCollectionAndTags | null>(null);
   const [editMode, setEditMode] = useState(false);
 
-  return (
-    <MainLayout>
-      <div className="p-5 flex flex-col gap-5 w-full h-full">
-        <LinkListOptions
-          t={t}
-          viewMode={viewMode}
-          setViewMode={setViewMode}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          editMode={editMode}
-          setEditMode={setEditMode}
-          links={links}
-        >
-          <PageHeader
-            icon={"bi-pin-angle"}
-            title={t("pinned")}
-            description={t("pinned_links_desc")}
-          />
-        </LinkListOptions>
+  const handleDragStart = (event: DragStartEvent) => {
+    const draggedLink = links.find(
+      (link: any) => link.id === event.active.data.current?.linkId
+    );
+    setActiveLink(draggedLink || null);
+  };
 
-        {!data.isLoading && links && !links[0] && (
-          <div
-            style={{ flex: "1 1 auto" }}
-            className="flex flex-col gap-2 justify-center h-full w-full mx-auto p-10"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="w-1/4 min-w-[7rem] max-w-[15rem] h-auto mx-auto mb-5 text-primary drop-shadow"
-              fill="currentColor"
-              viewBox="0 0 16 16"
-            >
-              <path d="M4.146.146A.5.5 0 0 1 4.5 0h7a.5.5 0 0 1 .5.5c0 .68-.342 1.174-.646 1.479-.126.125-.25.224-.354.298v4.431l.078.048c.203.127.476.314.751.555C12.36 7.775 13 8.527 13 9.5a.5.5 0 0 1-.5.5h-4v4.5c0 .276-.224 1.5-.5 1.5s-.5-1.224-.5-1.5V10h-4a.5.5 0 0 1-.5-.5c0-.973.64-1.725 1.17-2.189A6 6 0 0 1 5 6.708V2.277a3 3 0 0 1-.354-.298C4.342 1.674 4 1.179 4 .5a.5.5 0 0 1 .146-.354m1.58 1.408-.002-.001zm-.002-.001.002.001A.5.5 0 0 1 6 2v5a.5.5 0 0 1-.276.447h-.002l-.012.007-.054.03a5 5 0 0 0-.827.58c-.318.278-.585.596-.725.936h7.792c-.14-.34-.407-.658-.725-.936a5 5 0 0 0-.881-.61l-.012-.006h-.002A.5.5 0 0 1 10 7V2a.5.5 0 0 1 .295-.458 1.8 1.8 0 0 0 .351-.271c.08-.08.155-.17.214-.271H5.14q.091.15.214.271a1.8 1.8 0 0 0 .37.282" />
-            </svg>
-            <p className="text-center text-xl">
-              {t("pin_favorite_links_here")}
-            </p>
-            <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
-              {t("pin_favorite_links_here_desc")}
-            </p>
-          </div>
+  const handleDragOverCancel = () => {
+    setActiveLink(null);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { over } = event;
+    if (!over || !activeLink) return;
+
+    const collectionId = over.data.current?.collectionId as number;
+    const collectionName = over.data.current?.collectionName as string;
+    const ownerId = over.data.current?.ownerId as number;
+
+    // Immediately hide the drag overlay
+    setActiveLink(null);
+
+    // if the link dropped over the same collection, toast
+    if (activeLink.collection.id === collectionId) {
+      toast.error(t("link_already_in_collection"));
+      return;
+    }
+
+    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+      ...activeLink,
+      collection: {
+        id: collectionId,
+        name: collectionName,
+        ownerId,
+      },
+    };
+
+    const load = toast.loading(t("updating"));
+    await updateLink.mutateAsync(updatedLink, {
+      onSettled: (_, error) => {
+        toast.dismiss(load);
+        if (error) {
+          // If there's an error, invalidate queries to restore the original state
+          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
+          toast.error(error.message);
+        } else {
+          toast.success(t("updated"));
+        }
+      },
+    });
+  };
+
+  return (
+    <DndContext
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragOverCancel}
+      sensors={sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
+      modifiers={[snapCenterToCursor]}
+    >
+      <MainLayout>
+        {!!activeLink && (
+          <DragOverlay className="z-50 pointer-events-none">
+            <div className="w-fit h-fit">
+              <LinkIcon link={activeLink} />
+            </div>
+          </DragOverlay>
         )}
-        <Links
-          editMode={editMode}
-          links={links}
-          layout={viewMode}
-          placeholderCount={1}
-          useData={data}
-        />
-      </div>
-    </MainLayout>
+        <div className="p-5 flex flex-col gap-5 w-full h-full">
+          <LinkListOptions
+            t={t}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            editMode={editMode}
+            setEditMode={setEditMode}
+            links={links}
+          >
+            <PageHeader
+              icon={"bi-pin-angle"}
+              title={t("pinned")}
+              description={t("pinned_links_desc")}
+            />
+          </LinkListOptions>
+
+          {!data.isLoading && links && !links[0] && (
+            <div
+              style={{ flex: "1 1 auto" }}
+              className="flex flex-col gap-2 justify-center h-full w-full mx-auto p-10"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-1/4 min-w-[7rem] max-w-[15rem] h-auto mx-auto mb-5 text-primary drop-shadow"
+                fill="currentColor"
+                viewBox="0 0 16 16"
+              >
+                <path d="M4.146.146A.5.5 0 0 1 4.5 0h7a.5.5 0 0 1 .5.5c0 .68-.342 1.174-.646 1.479-.126.125-.25.224-.354.298v4.431l.078.048c.203.127.476.314.751.555C12.36 7.775 13 8.527 13 9.5a.5.5 0 0 1-.5.5h-4v4.5c0 .276-.224 1.5-.5 1.5s-.5-1.224-.5-1.5V10h-4a.5.5 0 0 1-.5-.5c0-.973.64-1.725 1.17-2.189A6 6 0 0 1 5 6.708V2.277a3 3 0 0 1-.354-.298C4.342 1.674 4 1.179 4 .5a.5.5 0 0 1 .146-.354m1.58 1.408-.002-.001zm-.002-.001.002.001A.5.5 0 0 1 6 2v5a.5.5 0 0 1-.276.447h-.002l-.012.007-.054.03a5 5 0 0 0-.827.58c-.318.278-.585.596-.725.936h7.792c-.14-.34-.407-.658-.725-.936a5 5 0 0 0-.881-.61l-.012-.006h-.002A.5.5 0 0 1 10 7V2a.5.5 0 0 1 .295-.458 1.8 1.8 0 0 0 .351-.271c.08-.08.155-.17.214-.271H5.14q.091.15.214.271a1.8 1.8 0 0 0 .37.282" />
+              </svg>
+              <p className="text-center text-xl">
+                {t("pin_favorite_links_here")}
+              </p>
+              <p className="text-center mx-auto max-w-96 w-fit text-neutral text-sm">
+                {t("pin_favorite_links_here_desc")}
+              </p>
+            </div>
+          )}
+          <Links
+            editMode={editMode}
+            links={links}
+            layout={viewMode}
+            placeholderCount={1}
+            useData={data}
+          />
+        </div>
+      </MainLayout>
+    </DndContext>
   );
 }
 

--- a/apps/web/pages/links/pinned.tsx
+++ b/apps/web/pages/links/pinned.tsx
@@ -22,7 +22,6 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import toast from "react-hot-toast";
-import { useQueryClient } from "@tanstack/react-query";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
@@ -58,7 +57,6 @@ export default function PinnedLinks() {
 
   const sensors = useSensors(mouseSensor, touchSensor);
 
-  const queryClient = useQueryClient();
   const updateLink = useUpdateLink();
   const [activeLink, setActiveLink] =
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
@@ -106,8 +104,6 @@ export default function PinnedLinks() {
       onSettled: (_, error) => {
         toast.dismiss(load);
         if (error) {
-          // If there's an error, invalidate queries to restore the original state
-          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
           toast.error(error.message);
         } else {
           toast.success(t("updated"));

--- a/apps/web/pages/search.tsx
+++ b/apps/web/pages/search.tsx
@@ -22,7 +22,6 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import { customCollisionDetectionAlgorithm } from "@/lib/utils";
 import { snapCenterToCursor } from "@dnd-kit/modifiers";
@@ -46,7 +45,6 @@ export default function Search() {
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
 
   const updateLink = useUpdateLink();
-  const queryClient = useQueryClient();
 
   const mouseSensor = useSensor(MouseSensor, {
     // Require the mouse to move by 10 pixels before activating
@@ -114,8 +112,6 @@ export default function Search() {
       onSettled: (_, error) => {
         toast.dismiss(load);
         if (error) {
-          // If there's an error, invalidate queries to restore the original state
-          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
           toast.error(error.message);
         } else {
           toast.success(t("updated"));

--- a/apps/web/pages/search.tsx
+++ b/apps/web/pages/search.tsx
@@ -1,6 +1,10 @@
-import { useLinks } from "@linkwarden/router/links";
+import { useLinks, useUpdateLink } from "@linkwarden/router/links";
 import MainLayout from "@/layouts/MainLayout";
-import { Sort, ViewMode } from "@linkwarden/types";
+import {
+  LinkIncludingShortenedCollectionAndTags,
+  Sort,
+  ViewMode,
+} from "@linkwarden/types";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import PageHeader from "@/components/PageHeader";
@@ -8,6 +12,21 @@ import LinkListOptions from "@/components/LinkListOptions";
 import getServerSideProps from "@/lib/client/getServerSideProps";
 import { useTranslation } from "next-i18next";
 import Links from "@/components/LinkViews/Links";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import { customCollisionDetectionAlgorithm } from "@/lib/utils";
+import { snapCenterToCursor } from "@dnd-kit/modifiers";
+import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
 
 export default function Search() {
   const { t } = useTranslation();
@@ -23,6 +42,27 @@ export default function Search() {
   );
 
   const [editMode, setEditMode] = useState(false);
+  const [activeLink, setActiveLink] =
+    useState<LinkIncludingShortenedCollectionAndTags | null>(null);
+
+  const updateLink = useUpdateLink();
+  const queryClient = useQueryClient();
+
+  const mouseSensor = useSensor(MouseSensor, {
+    // Require the mouse to move by 10 pixels before activating
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    // Press delay of 250ms, with tolerance of 5px of movement
+    activationConstraint: {
+      delay: 200,
+      tolerance: 5,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor, touchSensor);
 
   useEffect(() => {
     if (editMode) return setEditMode(false);
@@ -32,33 +72,100 @@ export default function Search() {
     sort: sortBy,
     searchQueryString: decodeURIComponent(router.query.q as string),
   });
+  const handleDragStart = (event: DragStartEvent) => {
+    const draggedLink = links.find(
+      (link: any) => link.id === event.active.data.current?.linkId
+    );
+    setActiveLink(draggedLink || null);
+  };
+
+  const handleDragOverCancel = () => {
+    setActiveLink(null);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { over } = event;
+    if (!over || !activeLink) return;
+
+    const collectionId = over.data.current?.collectionId as number;
+    const collectionName = over.data.current?.collectionName as string;
+    const ownerId = over.data.current?.ownerId as number;
+
+    // Immediately hide the drag overlay
+    setActiveLink(null);
+
+    // if the link dropped over the same collection, toast
+    if (activeLink.collection.id === collectionId) {
+      toast.error(t("link_already_in_collection"));
+      return;
+    }
+
+    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
+      ...activeLink,
+      collection: {
+        id: collectionId,
+        name: collectionName,
+        ownerId,
+      },
+    };
+
+    const load = toast.loading(t("updating"));
+    await updateLink.mutateAsync(updatedLink, {
+      onSettled: (_, error) => {
+        toast.dismiss(load);
+        if (error) {
+          // If there's an error, invalidate queries to restore the original state
+          queryClient.invalidateQueries({ queryKey: ["dashboardData"] });
+          toast.error(error.message);
+        } else {
+          toast.success(t("updated"));
+        }
+      },
+    });
+  };
 
   return (
-    <MainLayout>
-      <div className="p-5 flex flex-col gap-5 w-full h-full">
-        <LinkListOptions
-          t={t}
-          viewMode={viewMode}
-          setViewMode={setViewMode}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          editMode={editMode}
-          setEditMode={setEditMode}
-          links={links}
-        >
-          <PageHeader icon={"bi-search"} title={t("search_results")} />
-        </LinkListOptions>
+    <DndContext
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragOverCancel}
+      sensors={sensors}
+      collisionDetection={customCollisionDetectionAlgorithm}
+      modifiers={[snapCenterToCursor]}
+    >
+      <MainLayout>
+        {!!activeLink && (
+          <DragOverlay className="z-50 pointer-events-none">
+            <div className="w-fit h-fit">
+              <LinkIcon link={activeLink} />
+            </div>
+          </DragOverlay>
+        )}
+        <div className="p-5 flex flex-col gap-5 w-full h-full">
+          <LinkListOptions
+            t={t}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            editMode={editMode}
+            setEditMode={setEditMode}
+            links={links}
+          >
+            <PageHeader icon={"bi-search"} title={t("search_results")} />
+          </LinkListOptions>
 
-        {!data.isLoading && links && !links[0] && <p>{t("nothing_found")}</p>}
-        <Links
-          editMode={editMode}
-          links={links}
-          layout={viewMode}
-          placeholderCount={1}
-          useData={data}
-        />
-      </div>
-    </MainLayout>
+          {!data.isLoading && links && !links[0] && <p>{t("nothing_found")}</p>}
+          <Links
+            editMode={editMode}
+            links={links}
+            layout={viewMode}
+            placeholderCount={1}
+            useData={data}
+          />
+        </div>
+      </MainLayout>
+    </DndContext>
   );
 }
 

--- a/apps/web/pages/tags/[id].tsx
+++ b/apps/web/pages/tags/[id].tsx
@@ -7,7 +7,7 @@ import {
   TagIncludingLinkCount,
   ViewMode,
 } from "@linkwarden/types";
-import { useLinks, useUpdateLink } from "@linkwarden/router/links";
+import { useLinks } from "@linkwarden/router/links";
 import BulkDeleteLinksModal from "@/components/ModalContent/BulkDeleteLinksModal";
 import BulkEditLinksModal from "@/components/ModalContent/BulkEditLinksModal";
 import { useTranslation } from "next-i18next";
@@ -24,19 +24,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import {
-  DndContext,
-  DragEndEvent,
-  DragOverlay,
-  DragStartEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import { customCollisionDetectionAlgorithm } from "@/lib/utils";
-import { snapCenterToCursor } from "@dnd-kit/modifiers";
-import LinkIcon from "@/components/LinkViews/LinkComponents/LinkIcon";
+import DragNDrop from "@/components/DragNDrop";
 
 export default function Index() {
   const { t } = useTranslation();
@@ -45,7 +33,6 @@ export default function Index() {
   const { data: tags = [] } = useTags();
   const updateTag = useUpdateTag();
   const removeTag = useRemoveTag();
-  const updateLink = useUpdateLink();
 
   const [sortBy, setSortBy] = useState<Sort>(
     Number(localStorage.getItem("sortBy")) ?? Sort.DateNewestFirst
@@ -62,21 +49,6 @@ export default function Index() {
   const [activeLink, setActiveLink] =
     useState<LinkIncludingShortenedCollectionAndTags | null>(null);
 
-  const mouseSensor = useSensor(MouseSensor, {
-    // Require the mouse to move by 10 pixels before activating
-    activationConstraint: {
-      distance: 10,
-    },
-  });
-  const touchSensor = useSensor(TouchSensor, {
-    // Press delay of 250ms, with tolerance of 5px of movement
-    activationConstraint: {
-      delay: 200,
-      tolerance: 5,
-    },
-  });
-
-  const sensors = useSensors(mouseSensor, touchSensor);
   useEffect(() => {
     if (editMode) return setEditMode(false);
   }, [router]);
@@ -172,73 +144,13 @@ export default function Index() {
     (localStorage.getItem("viewMode") as ViewMode) || ViewMode.Card
   );
 
-  const handleDragStart = (event: DragStartEvent) => {
-    const draggedLink = links.find(
-      (link: any) => link.id === event.active.data.current?.linkId
-    );
-    setActiveLink(draggedLink || null);
-  };
-
-  const handleDragOverCancel = () => {
-    setActiveLink(null);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { over } = event;
-    if (!over || !activeLink) return;
-
-    const collectionId = over.data.current?.collectionId as number;
-    const collectionName = over.data.current?.collectionName as string;
-    const ownerId = over.data.current?.ownerId as number;
-
-    // Immediately hide the drag overlay
-    setActiveLink(null);
-
-    // if the link dropped over the same collection, toast
-    if (activeLink.collection.id === collectionId) {
-      toast.error(t("link_already_in_collection"));
-      return;
-    }
-
-    const updatedLink: LinkIncludingShortenedCollectionAndTags = {
-      ...activeLink,
-      collection: {
-        id: collectionId,
-        name: collectionName,
-        ownerId,
-      },
-    };
-
-    const load = toast.loading(t("updating"));
-    await updateLink.mutateAsync(updatedLink, {
-      onSettled: (_, error) => {
-        toast.dismiss(load);
-        if (error) {
-          toast.error(error.message);
-        } else {
-          toast.success(t("updated"));
-        }
-      },
-    });
-  };
-
   return (
-    <DndContext
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragOverCancel}
-      sensors={sensors}
-      collisionDetection={customCollisionDetectionAlgorithm}
-      modifiers={[snapCenterToCursor]}
+    <DragNDrop
+      links={links}
+      activeLink={activeLink}
+      setActiveLink={setActiveLink}
     >
       <MainLayout>
-        {!!activeLink && (
-          <DragOverlay className="z-50 pointer-events-none">
-            <div className="w-fit h-fit">
-              <LinkIcon link={activeLink} />
-            </div>
-          </DragOverlay>
-        )}
         <div className="p-5 flex flex-col gap-5 w-full">
           <LinkListOptions
             t={t}
@@ -339,7 +251,7 @@ export default function Index() {
           <BulkEditLinksModal onClose={() => setBulkEditLinksModal(false)} />
         )}
       </MainLayout>
-    </DndContext>
+    </DragNDrop>
   );
 }
 

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -208,6 +208,7 @@
   "password_successfully_updated": "Your password has been successfully updated.",
   "user_already_member": "User already exists.",
   "you_are_already_collection_owner": "You are already the collection owner.",
+  "link_already_in_collection": "Link is already in this collection.",
   "date_newest_first": "Date (Newest First)",
   "date_oldest_first": "Date (Oldest First)",
   "name_az": "Name (A-Z)",

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -208,7 +208,7 @@
   "password_successfully_updated": "Your password has been successfully updated.",
   "user_already_member": "User already exists.",
   "you_are_already_collection_owner": "You are already the collection owner.",
-  "link_already_in_collection": "Link is already in this collection.",
+  "link_already_in_collection": "This link is already in this collection.",
   "date_newest_first": "Date (Newest First)",
   "date_oldest_first": "Date (Oldest First)",
   "name_az": "Name (A-Z)",
@@ -493,5 +493,5 @@
   "edit_layout": "Edit Layout",
   "refresh_multiple_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve {{count}} links.",
   "refresh_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve this link.",
-  "tag_already_added": "This link is already tagged with this tag."
+  "tag_already_added": "This tag is already added."
 }

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -492,5 +492,6 @@
   "save": "Save",
   "edit_layout": "Edit Layout",
   "refresh_multiple_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve {{count}} links.",
-  "refresh_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve this link."
+  "refresh_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve this link.",
+  "tag_already_added": "This link is already tagged with this tag."
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,37 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/modifiers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz#96a0280c77b10c716ef79d9792ce7ad04370771d"
+  integrity sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@dominicstop/ts-event-emitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@dominicstop/ts-event-emitter/-/ts-event-emitter-1.1.0.tgz#1f3d3fa878a1ccab686931280757954719cf88e4"


### PR DESCRIPTION
- Drag-and-drop is a desired feature. I noticed there were other PRs, but not very active, so I made this attempt myself.
- This drag and drop applies to the dashboard page


Screen recording

### Drag and drop within dashboard

https://github.com/user-attachments/assets/d4113014-5be4-4c88-b43a-ad9c426d528a

### Drag and drop onto side bar

https://github.com/user-attachments/assets/d92b4483-1949-4685-864f-66f226a09643

