### PR TITLE
Fix: email input disappear in user modal

### DIFF
--- a/apps/web/components/ModalContent/InviteModal.tsx
+++ b/apps/web/components/ModalContent/InviteModal.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { signIn } from "next-auth/react";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
+import { useConfig } from "@linkwarden/router/config";
 
 type Props = {
   onClose: Function;
@@ -19,10 +20,10 @@ type FormData = {
   invite: boolean;
 };
 
-const emailEnabled = process.env.NEXT_PUBLIC_EMAIL_PROVIDER === "true";
-
 export default function InviteModal({ onClose }: Props) {
   const { t } = useTranslation();
+  const { data: config } = useConfig();
+  const emailEnabled = config?.EMAIL_PROVIDER;
 
   const addUser = useAddUser();
 

--- a/apps/web/components/ModalContent/NewUserModal.tsx
+++ b/apps/web/components/ModalContent/NewUserModal.tsx
@@ -6,6 +6,7 @@ import { useTranslation, Trans } from "next-i18next";
 import { useAddUser } from "@linkwarden/router/users";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
+import { useConfig } from "@linkwarden/router/config";
 
 type Props = {
   onClose: Function;
@@ -18,10 +19,10 @@ type FormData = {
   password: string;
 };
 
-const emailEnabled = process.env.NEXT_PUBLIC_EMAIL_PROVIDER === "true";
-
 export default function NewUserModal({ onClose }: Props) {
   const { t } = useTranslation();
+  const { data: config } = useConfig();
+  const emailEnabled = config?.EMAIL_PROVIDER;
 
   const addUser = useAddUser();
 


### PR DESCRIPTION
This PR fixes an issue where setting the `NEXT_PUBLIC_EMAIL_PROVIDER` environment variable to true did not show the email input field when creating or inviting a new user. As a result, the form would fail with an error because the email field was required but missing.