### PR TITLE
feat: hide cookie banner

### DIFF
--- a/apps/worker/lib/preservationScheme/handleScreenshotAndPdf.ts
+++ b/apps/worker/lib/preservationScheme/handleScreenshotAndPdf.ts
@@ -3,12 +3,16 @@ import { createFile } from "@linkwarden/filesystem";
 import { prisma } from "@linkwarden/prisma";
 import { LinkWithCollectionOwnerAndTags } from "@linkwarden/types";
 import { ArchivalSettings } from "@linkwarden/types";
+import { removeCookieBannersAndOverlays } from "./removeCookieBanners";
 
 const handleScreenshotAndPdf = async (
   link: LinkWithCollectionOwnerAndTags,
   page: Page,
   archivalSettings: ArchivalSettings
 ) => {
+  // Remove cookie banners and overlays before taking screenshot
+  await page.evaluate(removeCookieBannersAndOverlays);
+  
   await page.evaluate(autoScroll, Number(process.env.AUTOSCROLL_TIMEOUT) || 30);
 
   // Check if the user hasn't deleted the link by the time we're done scrolling

--- a/apps/worker/lib/preservationScheme/removeCookieBanners.ts
+++ b/apps/worker/lib/preservationScheme/removeCookieBanners.ts
@@ -1,0 +1,72 @@
+/**
+ * Function to hide cookie banners and modal overlays by injecting CSS
+ * This is the safest and most efficient approach
+ * 
+ * This function runs in the browser context via page.evaluate()
+ */
+export const removeCookieBannersAndOverlays = () => {
+  
+  // Create style element with CSS rules to hide cookie banners and modals
+  const style = document.createElement('style');
+  style.textContent = `
+    /* Hide native dialog elements and elements with ARIA roles */
+    dialog,
+    [role="dialog"],
+    [role="modal"],
+    [role="alertdialog"],
+    [role="banner"] {
+      opacity: 0 !important;
+    }
+    
+    /* Hide elements with backdrop/overlay/modal in class name */
+    [class*="backdrop"],
+    [class*="overlay"],
+    [class*="modal"],
+    [class*="dialog"],
+    [class*="cookie"] {
+      opacity: 0 !important;
+    }
+    
+    /* Hide elements with cookie/consent/banner in ID */
+    [id*="cookie"],
+    [id*="consent"],
+    [id*="banner"],
+    [id*="gdpr"],
+    [id*="privacy"] {
+      opacity: 0 !important;
+    }
+    
+    /* Remove modal/overlay states from body element */
+    body.modal-open,
+    body[class*="modal"],
+    body[class*="overlay"],
+    body[class*="scroll-lock"],
+    body[class*="no-scroll"],
+    body[class*="cookie"] {
+      overflow: auto !important;
+      position: static !important;
+      height: auto !important;
+    }
+  `;
+  
+  // Inject the CSS into the page
+  document.head.appendChild(style);
+
+  // Remove body classes related to modals and overlays.
+  // Hiding modal and overlay classes could otherwise result in an empty page.
+  const bodyClasses = document.body.className;
+  const modalRelatedClasses = bodyClasses.split(' ').filter(cls => 
+    cls.includes('modal') || 
+    cls.includes('overlay') || 
+    cls.includes('scroll') || 
+    cls.includes('no-scroll') ||
+    cls.includes('lock') ||
+    cls.includes('cookie') ||
+    cls.includes('consent') ||
+    cls.includes('banner')
+  );
+  
+  modalRelatedClasses.forEach(cls => {
+    document.body.classList.remove(cls);
+  });
+};


### PR DESCRIPTION
Adressing #138 

This pull request improves the quality and reliability of screenshots and PDF captures by programmatically removing cookie banners and modal overlays from web pages before capturing. The main changes introduce a utility function to inject CSS and clean up DOM elements that typically obstruct content, and integrate this step into the screenshot/PDF workflow.

Enhancements to screenshot and PDF capture:

* Added a new utility function `removeCookieBannersAndOverlays` in `removeCookieBanners.ts` to inject CSS that hides common cookie banners, modals, overlays, and related elements, and to remove modal-related classes from the `body` element. This ensures cleaner captures by preventing overlays from obscuring page content.
* Integrated the `removeCookieBannersAndOverlays` function into the `handleScreenshotAndPdf` workflow, so that banners and overlays are removed before taking screenshots or generating PDFs.

I think this is a feature we all want, because almost every website now has some kind of cookie consent banner, which makes almost every screenshot unusable.

I tested it with around 20 popular sites, and it performed really well. I'm curious to hear your feedback.