### PR TITLE
Fix: request 64px gstatic favicon for consistent icon display

### DIFF
--- a/apps/web/components/LinkViews/LinkComponents/LinkIcon.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkIcon.tsx
@@ -45,7 +45,7 @@ export default function LinkIcon({
       ) : link.type === "url" && url ? (
         <>
           <Image
-            src={`https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${link.url}&size=32`}
+            src={`https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${link.url}&size=64`}
             width={64}
             height={64}
             alt=""


### PR DESCRIPTION
Previously, a 32px favicon was requested and scaled to 64px, causing blurriness.