### PR TITLE
fix: allow adding email when disabled during setup

### DIFF
--- a/apps/web/lib/api/controllers/users/userId/updateUserById.ts
+++ b/apps/web/lib/api/controllers/users/userId/updateUserById.ts
@@ -101,7 +101,11 @@ export default async function updateUserById(
     where: { id: userId },
   });
 
-  if (user && user.email && data.email && data.email !== user.email) {
+  if (
+    (user && user.email && data.email && data.email !== user.email) ||
+    // setting up email for the first time
+    (user && !user.email && data.email)
+  ) {
     if (!data.password) {
       return {
         response: "Invalid password.",
@@ -127,11 +131,12 @@ export default async function updateUserById(
       };
     }
 
-    sendChangeEmailVerificationRequest(
-      user.email,
-      data.email,
-      data.name?.trim() || user.name || "Linkwarden User"
-    );
+    sendChangeEmailVerificationRequest({
+      oldEmail: user.email,
+      newEmail: data.email,
+      username: user.username,
+      user: data.name?.trim() || user.name || "Linkwarden User",
+    });
   }
 
   // Password Settings


### PR DESCRIPTION
Fixes an issue where users could not add an email if one was not set during account registration. This occurred in self-hosted setups where `NEXT_PUBLIC_EMAIL_PROVIDER` was `false` or `undefined`. Later, when email was enabled, users were unable to add a new email to their account.