### PR TITLE
Docker Compose improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     restart: always
-    # build: . # uncomment to build from source
+    # build: # uncomment section and one of 'context' lines below to build from source
+    #   context: .
+    #   context: https://github.com/linkwarden/linkwarden.git#dev
     image: ghcr.io/linkwarden/linkwarden:latest # comment to build from source
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     image: postgres:16-alpine
     env_file: .env
     restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      interval: 10s
+      start_period: 20s
+      start_interval: 1s
+      timeout: 1s
     volumes:
       - type: bind
         source: ./pgdata
@@ -26,8 +32,13 @@ services:
         target: /data/data
         read_only: false
     depends_on:
-      - postgres
-      - meilisearch
+      postgres:
+        condition: service_healthy
+        required: true
+      meilisearch:
+        condition: service_started
+        required: true
+
   meilisearch:
     image: getmeili/meilisearch:v1.12.8
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,11 @@ services:
     env_file: .env
     restart: always
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - type: bind
+        source: ./pgdata
+        target: /var/lib/postgresql/data
+        read_only: false
+
   linkwarden:
     env_file: .env
     environment:
@@ -15,7 +19,10 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./data:/data/data
+      - type: bind
+        source: ./data
+        target: /data/data
+        read_only: false
     depends_on:
       - postgres
       - meilisearch
@@ -25,4 +32,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./meili_data:/meili_data
+      - type: bind
+        source: ./meili_data
+        target: /meili_data
+        read_only: false


### PR DESCRIPTION
Some Docker Compose improvements: 
* (readability) use long syntax for volumes.
* Add option for building from a git URL. URL supports repo#branch. Build from latest `HEAD`, from a PR or from your own fork without cloning (just the `docker-compose.yml` file).
* Add healthcheck to Postgres and make app service await for its healthiness. You'll notice app service starts booting after Postgres is up.