### PR TITLE
Add admin feature for batch cleanup of unused/unwanted tags (by count)

### DIFF
--- a/apps/web/lib/api/controllers/tags/cleanupTags.ts
+++ b/apps/web/lib/api/controllers/tags/cleanupTags.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@linkwarden/prisma/client";
+
+export default async function cleanupTags(minLinksPerTag: number) {
+  const prisma = new PrismaClient();
+
+  const deletedCount = await prisma.$executeRawUnsafe(
+    `
+    DELETE FROM "Tag"
+    WHERE id IN (
+      SELECT T.id
+      FROM "Tag" T
+      LEFT JOIN "_LinkToTag" LTT ON T.id = LTT."B"
+      GROUP BY T.id
+      HAVING COUNT(LTT."A") <= $1
+    );
+  `,
+    minLinksPerTag
+  );
+
+  return deletedCount;
+}

--- a/apps/web/lib/client/getServerSideProps.ts
+++ b/apps/web/lib/client/getServerSideProps.ts
@@ -21,6 +21,7 @@ const getServerSideProps: GetServerSideProps = async (ctx) => {
       return {
         props: {
           ...(await serverSideTranslations(user.locale ?? "en", ["common"])),
+	  minLinksPerTag: process.env.MIN_LINKS_PER_TAG || "0",
         },
       };
     }
@@ -50,6 +51,7 @@ const getServerSideProps: GetServerSideProps = async (ctx) => {
   return {
     props: {
       ...(await serverSideTranslations(bestMatch ?? "en", ["common"])),
+      minLinksPerTag: process.env.MIN_LINKS_PER_TAG || "0",
     },
   };
 };

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -22,6 +22,7 @@ const nextConfig = {
   transpilePackages: ["@linkwarden/prisma"],
   env: {
     version,
+    MIN_LINKS_PER_TAG: process.env.MIN_LINKS_PER_TAG,
   },
   webpack(config) {
     config.resolve.fallback = {

--- a/apps/web/pages/api/v1/tags/cleanup.ts
+++ b/apps/web/pages/api/v1/tags/cleanup.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import verifyUser from "@/lib/api/verifyUser";
+import cleanupTags from "@/lib/api/controllers/tags/cleanupTags";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  try {
+    const user = await verifyUser({ req, res });
+
+    if (!user) {
+      return res.status(401).json({ message: "Unauthorized." });
+    }
+
+    // from what I can find online first use IS the admin
+    if (user.id !== 1) {
+      return res.status(403).json({ message: "Forbidden: Access is denied." });
+    }
+
+    const { threshold } = req.body;
+    const deletedCount = await cleanupTags(threshold);
+
+    return res
+      .status(200)
+      .json({ message: `Successfully deleted ${deletedCount} tags.` });
+      
+  } catch (error) {
+    console.error("Tag cleanup failed:", error);
+    return res.status(500).json({ message: "An unexpected error occurred." });
+  }
+}

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -493,5 +493,7 @@
   "edit_layout": "Edit Layout",
   "refresh_multiple_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve {{count}} links.",
   "refresh_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve this link.",
-  "tag_already_added": "This tag is already added."
+  "tag_already_added": "This tag is already added.",
+  "delete_unused_tags_desc": "Delete all tags with {{count}} or fewer links, applies to all users.",
+  "delete_unused_tags_confirm": "Are you sure you want to delete all tags with {{count}} or fewer links? This action is irreversible."
 }


### PR DESCRIPTION
Reference:  https://github.com/linkwarden/linkwarden/issues/1148

With the addition of ai tags, depending on the set configuration, many tags show up with only 1 link which either you manually move to another tag or you just swear under your breath wishing they would magically go away.  Beyond that removing links, or collection of links, can leave behind tags with 0 links associated.  Since the tags sit so prominently on the left side having unwanted tags adds clutter.  Deleting 1-2 tags is no issue but in my case there were more than 175 that I wanted gone.

Per a couple of requests I saw of others wanting the same thing, this pull request introduces a new administrative tool to remove unused/unwanted tags based on count.  By default the GUI deletes tags with 0 links associated.  However, adding a new env var "MIN_LINKS_PER_TAG=" to a docker compose file or .env file, the user can set the minimum links to tags that works for their comfort level.  In issue 1148 it sounded like 1-2 links per tag were a preference for that user, while for me it would likely always be tags with 0 links -- but hey this gives options to people who want to configure it to what works for them.


### Testing suggestion

    For testing tags with 1 or more links associated, add the MIN_LINKS_PER_TAG environment variable in 
    the .env file or docker-compose otherwise only tags with 0 links associated will be targeted

    Ensure there are some tags that fall below the threshold

    Login as the admin user (the first account created)

    Go to Settings > Worker

    Verify that the UI correctly displays the threshold matching the env var 
    "Delete all tags with XX or fewer links, applies to all users."

    Clicking the "Confirm" button which will provide the "are you sure" prompt

    Volia! A popup will confirm xx links have been deleted and jumping back to the dashboard 
    the targeted tags should no longer show
    
### Glamour shots

<img width="774" height="356" alt="Screenshot From 2025-08-28 13-29-56" src="https://github.com/user-attachments/assets/6a194c76-8f2f-449b-984c-b34f03b8d4aa" />

<img width="410" height="110" alt="Screenshot From 2025-08-28 13-30-13" src="https://github.com/user-attachments/assets/f2ba2fbe-5c52-44bc-a16e-762bc27167af" />

<img width="574" height="398" alt="Screenshot From 2025-08-28 13-30-22" src="https://github.com/user-attachments/assets/fc16cae0-20d6-441b-aae6-40d11bdd9b1a" />
