### PR TITLE
Add link setting for 'Copy link to clipboard'

### DIFF
--- a/apps/web/lib/client/openLink.ts
+++ b/apps/web/lib/client/openLink.ts
@@ -4,6 +4,7 @@ import {
 } from "@linkwarden/types";
 import { generateLinkHref } from "@linkwarden/lib/generateLinkHref";
 import { LinksRouteTo } from "@linkwarden/prisma/client";
+import { toast } from "react-hot-toast";
 
 const openLink = (
   link: LinkIncludingShortenedCollectionAndTags,
@@ -12,6 +13,12 @@ const openLink = (
 ) => {
   if (user.linksRouteTo === LinksRouteTo.DETAILS) {
     openModal();
+  } else if (user.linksRouteTo === LinksRouteTo.COPY) {
+    if (link.url) {
+      navigator.clipboard.writeText(link.url);
+      // non-react > string required for user feedback
+      toast.success("Copied to clipboard");
+    }
   } else {
     window.open(generateLinkHref(link, user), "_blank");
   }

--- a/apps/web/pages/settings/preference.tsx
+++ b/apps/web/pages/settings/preference.tsx
@@ -602,6 +602,22 @@ export default function Preference() {
                 {t("open_screenshot_if_available")}
               </span>
             </label>
+
+	    <label
+ 	      className="label cursor-pointer flex gap-2 justify-start w-fit"
+	      tabIndex={0}
+	      role="button"
+	    >
+	      <input
+	        type="radio"
+	        name="link-preference-radio"
+	        className="radio checked:bg-primary"
+	        value="Copy"
+	        checked={linksRouteTo === LinksRouteTo.COPY}
+	        onChange={() => setLinksRouteTo(LinksRouteTo.COPY)}
+	      />
+	      <span className="label-text">{t("copy_link_to_clipboard")}</span>
+	    </label>
           </div>
         </div>
 

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -493,5 +493,6 @@
   "edit_layout": "Edit Layout",
   "refresh_multiple_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve {{count}} links.",
   "refresh_preserved_formats_confirmation_desc": "This will delete the current preserved formats and re-preserve this link.",
-  "tag_already_added": "This tag is already added."
+  "tag_already_added": "This tag is already added.",
+  "copy_link_to_clipboard": "Copy link to clipboard"
 }

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -92,6 +92,7 @@ enum LinksRouteTo {
   MONOLITH
   SCREENSHOT
   DETAILS
+  COPY
 }
 
 model WhitelistedUser {


### PR DESCRIPTION
Reference: https://github.com/linkwarden/linkwarden/issues/530

New preference in settings allowing clicking on a link and copying the URL to the clipboard.  In request 530 the use case was users who use multiple browsers whether it be for work or other reasons.

I wasn't sure an icon on each link card would be accepted when this feature is likely not that exciting to most so following existing form and adhering to an uncluttered interface it was added as a global preference.

Settings > Preference > Link Settings > Copy link to clipboard

Code is centralized to a openLink.ts helper func
All other link actions have been tested on a couple docker instances on different hardware and remain working as before


### Glamour shots
<img width="311" height="526" alt="Screenshot From 2025-08-29 10-45-05" src="https://github.com/user-attachments/assets/100631f7-1c30-448a-9b6a-fe06dee74c2a" />


toast notification:
<img width="218" height="75" alt="Screenshot From 2025-08-29 10-45-30" src="https://github.com/user-attachments/assets/217dccb5-a353-42f0-a2cf-47982478d04e" />
