### PR TITLE
fix: support using monolith content for other archive formats

### DIFF
--- a/apps/web/pages/api/v1/archives/index.ts
+++ b/apps/web/pages/api/v1/archives/index.ts
@@ -162,6 +162,11 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
             },
           },
           url,
+
+          // temporarily prevent archiveHandler and other processes from overwriting the file while we're uploading it
+          lastPreserved: new Date(0).toISOString(),
+          aiTagged: true,
+          indexVersion: 1,
         },
       });
 
@@ -203,6 +208,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
               : undefined,
           clientSide: true,
           updatedAt: new Date().toISOString(),
+
+          lastPreserved: null,
+          aiTagged: false,
+          indexVersion: null,
         },
       });
 

--- a/apps/worker/lib/archiveHandler.ts
+++ b/apps/worker/lib/archiveHandler.ts
@@ -120,7 +120,7 @@ export default async function archiveHandler(
           await page.goto(link.url, { waitUntil: "domcontentloaded" });
 
           // Handle Monolith being sent in beforehand while making sure other values line up
-          if (link.monolith) {
+          if (link.monolith?.endsWith(".html")) {
             // Use Monolith content instead of page
             const file = await readFile(link.monolith);
 
@@ -128,9 +128,13 @@ export default async function archiveHandler(
               const fileContent = file.file;
 
               if (typeof fileContent === "string") {
-                await page.setContent(fileContent, { waitUntil: "domcontentloaded" });
+                await page.setContent(fileContent, {
+                  waitUntil: "domcontentloaded",
+                });
               } else {
-                await page.setContent(fileContent.toString("utf-8"), { waitUntil: "domcontentloaded" });
+                await page.setContent(fileContent.toString("utf-8"), {
+                  waitUntil: "domcontentloaded",
+                });
               }
             }
           }


### PR DESCRIPTION
Fixes #1384 #1392 and #1386