### PR TITLE
Allow running Docker container as non-root user

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,13 @@ DATABASE_URL=
 # Docker installation database settings
 POSTGRES_PASSWORD=
 
+# Run processes inside container as specific user/group. Defaults to root.
+# WARNING: if docker is run using `sudo`, create all mounted directories with
+# correct ownership before starting the container, or else the directories will
+# be created with root ownership which can conflict with the uid/gid set here.
+PUID=
+PGID=
+
 # Additional Optional Settings
 PAGINATION_TAKE_COUNT=
 STORAGE_FOLDER=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:16-alpine
+    user: '${PUID:-0}:${PGID:-0}'
     env_file: .env
     restart: always
     volumes:
@@ -21,6 +22,7 @@ services:
       - meilisearch
   meilisearch:
     image: getmeili/meilisearch:v1.12.8
+    user: '${PUID:-0}:${PGID:-0}'
     restart: always
     env_file:
       - .env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+set -e
+
+# Fix permissions for non-root users (excluding mounted volume /data/data and
+# large directories like node_modules).
+find /data \
+     -path /data/data -prune -o \
+     -path '*/node_modules' -prune -o \
+     -type d -exec chmod 777 {} + 2>/dev/null || true
+
+# Drop privileges if PUID/PGID are set.
+if [ -n "$PUID" ] && [ -n "$PGID" ]; then
+    exec gosu "$PUID:$PGID" env HOME=/data/home "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This is a modification and rebase of #779 to allow running Docker containers as a non-root user.

Main changes from that PR:

- went with PUID/PGID variable names to match the linuxserver.io convention, which avoids conflicts with reserved UID/GID variables.
- setting `HOME` environment variable to `/home` so Playwright is installed there and can be accessed by non-root users (setting `ENV PLAYWRIGHT_BROWSERS_PATH` did not do the trick for me).
- setting permissions in an entrypoint script (requires root), then dropping root privileges using gosu if PUID/PGID are set.

I verified that the Docker image size did not change between `linkwarden:latest` and this new image (both 2.48GB), which I saw a concern in #779. The reason that PR caused the size increase was due to its `chmod -R ... /data` inside the RUN command - changing permissions in this way creates a new layer which duplicates all the files in `/data` with the new permissions. By switching to an entrypoint script that sets permissions the layer-duplication problem is avoided.

I tested:
- running without a custom user
- running with custom PUID/PGID
- running on linkwarden:latest, then upgrading to new image without changing anything else (to verify backwards compatibility)

In all cases I was able to create an account, login, and add links without any diverging warnings or errors in the logs. The backwards compatibility case had no issues.

Fixes https://github.com/linkwarden/linkwarden/issues/550
Fixes https://github.com/linkwarden/linkwarden/issues/655
Fixes https://github.com/linkwarden/linkwarden/issues/712