### PR TITLE
Add configurable HTTP timeout for Authentik provider

### DIFF
--- a/apps/web/pages/api/v1/auth/[...nextauth].ts
+++ b/apps/web/pages/api/v1/auth/[...nextauth].ts
@@ -351,7 +351,7 @@ if (process.env.NEXT_PUBLIC_AUTHENTIK_ENABLED === "true") {
       clientSecret: process.env.AUTHENTIK_CLIENT_SECRET!,
       issuer: process.env.AUTHENTIK_ISSUER,
       httpOptions: {
-        timeout: parseInt(process.env.AUTHENTIK_HTTP_TIMEOUT || "10000", 10),
+        timeout: 10000,
       },
       profile: (profile) => {
         return {


### PR DESCRIPTION
Suggestion as a fix for https://github.com/linkwarden/linkwarden/issues/788
Edited the function to implement the same function as for the google authentication. New env: AUTHENTIK_HTTP_TIMEOUT defaults to 10000 (10s)