### PR TITLE
PR: Auto-clean orphan AI-generated tags when links are removed - #1470

### DIFF
--- a/apps/web/lib/api/controllers/links/bulk/deleteLinksById.ts
+++ b/apps/web/lib/api/controllers/links/bulk/deleteLinksById.ts
@@ -1,8 +1,8 @@
-import { prisma } from "@linkwarden/prisma";
-import { UsersAndCollections } from "@linkwarden/prisma/client";
 import getPermission from "@/lib/api/getPermission";
 import { removeFiles } from "@linkwarden/filesystem";
 import { meiliClient } from "@linkwarden/lib";
+import { prisma } from "@linkwarden/prisma";
+import { UsersAndCollections } from "@linkwarden/prisma/client";
 
 export default async function deleteLinksById(
   userId: number,
@@ -32,6 +32,21 @@ export default async function deleteLinksById(
     collectionIsAccessibleArray.push(collectionIsAccessible);
   }
 
+  // Get AI-generated tags BEFORE deleting the links
+  const linksWithTags = await prisma.link.findMany({
+    where: { id: { in: linkIds } },
+    select: {
+      createdById: true,
+      tags: {
+        where: { aiGenerated: true },
+        select: { id: true }
+      }
+    }
+  });
+
+  const aiTagIds = linksWithTags.flatMap(l => l.tags.map(t => t.id));
+  const ownerIds = Array.from(new Set(linksWithTags.map(l => l.createdById).filter((id): id is number => id !== null)));
+
   const deletedLinks = await prisma.link.deleteMany({
     where: {
       id: { in: linkIds },
@@ -48,6 +63,25 @@ export default async function deleteLinksById(
   }
 
   await meiliClient?.index("links").deleteDocuments(linkIds);
+
+  // Clean up orphan AI-generated tags (tags with no remaining links)
+  if (aiTagIds.length > 0 && ownerIds.length > 0) {
+    try {
+      const { count } = await prisma.tag.deleteMany({
+        where: {
+          id: { in: aiTagIds },
+          ownerId: { in: ownerIds },
+          aiGenerated: true,
+          links: { none: {} }
+        }
+      });
+      if (count > 0) {
+        console.log(`Removed ${count} AI-generated orphan tags`);
+      }
+    } catch (error) {
+      console.error("Failed to remove AI-generated orphan tags", { linkIds, error });
+    }
+  }
 
   return { response: deletedLinks, status: 200 };
 }

--- a/apps/web/lib/api/controllers/links/linkId/deleteLinkById.ts
+++ b/apps/web/lib/api/controllers/links/linkId/deleteLinkById.ts
@@ -1,8 +1,8 @@
-import { prisma } from "@linkwarden/prisma";
-import { Link, UsersAndCollections } from "@linkwarden/prisma/client";
 import getPermission from "@/lib/api/getPermission";
 import { removeFiles } from "@linkwarden/filesystem";
 import { meiliClient } from "@linkwarden/lib";
+import { prisma } from "@linkwarden/prisma";
+import { Link, UsersAndCollections } from "@linkwarden/prisma/client";
 
 export default async function deleteLink(userId: number, linkId: number) {
   if (!linkId) return { response: "Please choose a valid link.", status: 401 };
@@ -19,6 +19,20 @@ export default async function deleteLink(userId: number, linkId: number) {
   )
     return { response: "Collection is not accessible.", status: 401 };
 
+  // Get AI-generated tags BEFORE deleting the link
+  const linkWithTags = await prisma.link.findUnique({
+    where: { id: linkId },
+    include: {
+      tags: {
+        where: { aiGenerated: true },
+        select: { id: true, ownerId: true }
+      }
+    }
+  });
+
+  const aiTagIds = linkWithTags?.tags.map(t => t.id) ?? [];
+  const ownerId = linkWithTags?.createdById;
+
   const deleteLink: Link = await prisma.link.delete({
     where: {
       id: linkId,
@@ -28,6 +42,25 @@ export default async function deleteLink(userId: number, linkId: number) {
   removeFiles(linkId, collectionIsAccessible.id);
 
   await meiliClient?.index("links").deleteDocument(deleteLink.id);
+
+  // Clean up orphan AI-generated tags (tags with no remaining links)
+  if (aiTagIds.length > 0 && ownerId) {
+    try {
+      const { count } = await prisma.tag.deleteMany({
+        where: {
+          id: { in: aiTagIds },
+          ownerId: ownerId,
+          aiGenerated: true,
+          links: { none: {} }
+        }
+      });
+      if (count > 0) {
+        console.log(`Removed ${count} AI-generated orphan tags`);
+      }
+    } catch (error) {
+      console.error("Failed to remove AI-generated orphan tags", { linkId, error });
+    }
+  }
 
   return { response: deleteLink, status: 200 };
 }

--- a/apps/web/lib/api/controllers/tags/removeOrphanTags.ts
+++ b/apps/web/lib/api/controllers/tags/removeOrphanTags.ts
@@ -1,0 +1,68 @@
+import getPermission from "@/lib/api/getPermission";
+import { prisma } from "@linkwarden/prisma";
+
+
+export async function removeAllOrphanTags(userId: number, collectionId?: number) {
+	const tagIsAccessible = await getPermission({ userId, collectionId });
+
+	if (!tagIsAccessible) {
+		return { response: "Access denied", status: 403 };
+	}
+
+	const { count } = await prisma.tag.deleteMany({
+		where: {
+			ownerId: userId,
+			aiGenerated: true,
+			links: {
+				none: {}
+			}
+		}
+	});
+
+	if (count === 0) {
+		return { response: "No AI-generated orphan tags to remove", status: 200 };
+	}
+
+	return { response: `Removed ${count} AI-generated orphan tags`, status: 200 };
+}
+
+export async function removeOrphanTagFromLink(linkId: number): Promise<{ response: string; status: number }> {
+	const link = await prisma.link.findUnique({
+		where: { id: linkId },
+		include: {
+			tags: {
+				where: { aiGenerated: true },
+				include: {
+					_count: {
+						select: { links: true }
+					}
+				}
+			}
+		}
+	});
+
+	if (!link) {
+		return { response: "Link not found", status: 404 };
+	}
+
+	if (!link.createdById) {
+		return { response: "Cannot determine link owner.", status: 400 };
+	}
+
+	const orphanTags = link.tags.filter(tag => (tag._count?.links ?? 0) <= 1);
+
+	if (orphanTags.length === 0) {
+		return { response: "No AI-generated orphan tags to remove", status: 200 };
+	}
+
+	await prisma.tag.deleteMany({
+		where: {
+			ownerId: link.createdById,
+			id: {
+				in: orphanTags.map(tag => tag.id)
+			}
+		}
+	});
+
+	return { response: `Removed ${orphanTags.length} AI-generated orphan tags`, status: 200 };
+}


### PR DESCRIPTION
Summary
Single-link deletions now clean up AI tags – When a link is deleted, any AI-generated tags that no longer belong to another link are removed immediately, preventing “ghost” tags from piling up in users’ collections. 
Bulk deletions receive the same treatment – Deleting several links in one request now batch-removes orphaned AI tags for all affected owners.
New tag-maintenance helpers – Added APIs to remove all orphaned AI tags for a user, or only those tied to a specific link, so we can expand UI controls later without reworking backend logic.

Testing
Deleted a single link that had unique AI tags - tags disappeared as expected.
Deleted multiple links sharing tags - tags only removed when no remaining links referenced them.
Tried deleting links with no AI tags - no tag deletions triggered, confirming guard rails work.

Considerations for Settings UI
“Sweep orphan tags” button – The new removeAllOrphanTags controller gives us everything needed for a one-click cleanup in Settings. A button could call this endpoint and show how many tags were removed (or if nothing was found). I noticed there are responses with descriptive text to them, so I kept it.
Optional auto-clean toggle – Some users might prefer manual control, so exposing a toggle like “Auto-delete AI tags when their last link is removed” keeps flexibility. The current backend already deletes orphans during link removal, but the toggle could decide whether we invoke that cleanup or skip it for advanced workflows. A user preference flag stored alongside other settings would do the trick, and the existing helper gives us the required logic without additional queries.

Let me know of your feedback! Thanks!