### PR TITLE
Fix/admin sub-collection permission

### DIFF
--- a/apps/web/lib/api/controllers/collections/postCollection.ts
+++ b/apps/web/lib/api/controllers/collections/postCollection.ts
@@ -6,6 +6,7 @@ import {
 } from "@linkwarden/lib/schemaValidation";
 import getPermission from "@/lib/api/getPermission";
 import { UsersAndCollections } from "@linkwarden/prisma/client";
+import getCollectionRootOwnerAndMembers from "../../getCollectionRootOwnerAndMembers";
 
 export default async function postCollection(
   body: PostCollectionSchemaType,
@@ -24,52 +25,60 @@ export default async function postCollection(
 
   const collection = dataValidation.data;
 
-  let parentCollectionMembers: UsersAndCollections[] = [];
+  let rootOwnerId = userId;
+  let dedupedUsers: {
+    userId: number;
+    canCreate: boolean;
+    canUpdate: boolean;
+    canDelete: boolean;
+  }[] = [];
 
   if (collection.parentId) {
-    const findParentCollection = await prisma.collection.findUnique({
-      where: {
-        id: collection.parentId,
-      },
-      select: {
-        ownerId: true,
-        members: true,
-      },
-    });
-
-    if (findParentCollection) {
-      parentCollectionMembers = (
-        findParentCollection.members as UsersAndCollections[]
-      ).filter((member) => member.userId !== userId);
-
-      if (findParentCollection.ownerId !== userId) {
-        parentCollectionMembers.push({
-          userId: findParentCollection.ownerId,
-          canCreate: true,
-          canUpdate: true,
-          canDelete: true,
-        } as UsersAndCollections);
-      }
-
-      console.log("Parent collection members:", parentCollectionMembers);
+    if (typeof collection.parentId !== "number") {
+      return {
+        response: "Invalid parentId.",
+        status: 400,
+      };
     }
-    const collectionIsAccessible = await getPermission({
-      userId: userId,
+
+    const permissionCheck = await getPermission({
+      userId,
       collectionId: collection.parentId,
     });
-    const memberHasAccess = collectionIsAccessible?.members.some(
-      (e: UsersAndCollections) => e.userId === userId && e.canCreate && e.canUpdate && e.canDelete
+
+    const memberHasAccess = permissionCheck?.members.some(
+      (e: UsersAndCollections) =>
+        e.userId === userId && e.canCreate && e.canUpdate && e.canDelete
     );
 
-
-    if (
-      (findParentCollection?.ownerId !== userId && !memberHasAccess) ||
-      typeof collection.parentId !== "number"
-    )
+    if (!memberHasAccess && permissionCheck?.ownerId !== userId) {
       return {
         response: "You are not authorized to create a sub-collection here.",
         status: 403,
       };
+    }
+
+    const result = await getCollectionRootOwnerAndMembers(collection.parentId);
+
+    if (!result.rootOwnerId) {
+      return {
+        response: "Parent collection not found.",
+        status: 404,
+      };
+    }
+
+    rootOwnerId = result.rootOwnerId;
+    dedupedUsers = result.members;
+
+    const exists = dedupedUsers.some((u) => u.userId === userId);
+    if (!exists) {
+      dedupedUsers.push({
+        userId,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      });
+    }
   }
 
   const newCollection = await prisma.collection.create({
@@ -79,43 +88,32 @@ export default async function postCollection(
       color: collection.color,
       icon: collection.icon,
       iconWeight: collection.iconWeight,
-      members: {
-        create: parentCollectionMembers.map((member) => ({
-          userId: member.userId,
-          canCreate: member.canCreate,
-          canUpdate: member.canUpdate,
-          canDelete: member.canDelete,
-        })),
-      },
-      parent: collection.parentId
-        ? {
-            connect: {
-              id: collection.parentId,
-            },
-          }
-        : undefined,
       owner: {
-        connect: {
-          id: userId,
-        },
+        connect: { id: rootOwnerId },
       },
       createdBy: {
-        connect: {
-          id: userId,
-        },
+        connect: { id: userId },
       },
+      members: {
+        create: dedupedUsers
+          .filter((u) => u.userId !== rootOwnerId)
+          .map((u) => ({
+            userId: u.userId,
+            canCreate: u.canCreate,
+            canUpdate: u.canUpdate,
+            canDelete: u.canDelete,
+          })),
+      },
+      parent: collection.parentId
+        ? { connect: { id: collection.parentId } }
+        : undefined,
     },
     include: {
-      _count: {
-        select: { links: true },
-      },
+      _count: { select: { links: true } },
       members: {
         include: {
           user: {
-            select: {
-              username: true,
-              name: true,
-            },
+            select: { username: true, name: true },
           },
         },
       },
@@ -123,13 +121,9 @@ export default async function postCollection(
   });
 
   await prisma.user.update({
-    where: {
-      id: userId,
-    },
+    where: { id: userId },
     data: {
-      collectionOrder: {
-        push: newCollection.id,
-      },
+      collectionOrder: { push: newCollection.id },
     },
   });
 

--- a/apps/web/lib/api/getCollectionRootOwnerAndMembers.ts
+++ b/apps/web/lib/api/getCollectionRootOwnerAndMembers.ts
@@ -1,0 +1,74 @@
+import { prisma } from "@linkwarden/prisma";
+import { UsersAndCollections } from "@linkwarden/prisma/client";
+
+type MemberPerms = Pick<
+  UsersAndCollections,
+  "userId" | "canCreate" | "canUpdate" | "canDelete"
+>;
+
+function mergePerms(a: MemberPerms, b: MemberPerms): MemberPerms {
+  return {
+    userId: a.userId,
+    canCreate: a.canCreate || b.canCreate,
+    canUpdate: a.canUpdate || b.canUpdate,
+    canDelete: a.canDelete || b.canDelete,
+  };
+}
+
+export default async function getCollectionRootOwnerAndMembers(
+  parentId: number
+) {
+  const userMap = new Map<number, MemberPerms>();
+
+  const addUser = (u: MemberPerms) => {
+    const existing = userMap.get(u.userId);
+    userMap.set(u.userId, existing ? mergePerms(existing, u) : u);
+  };
+
+  let currentId: number | null = parentId;
+  let rootOwnerId: number | null = null;
+
+  while (currentId) {
+    const col: {
+      parentId: number | null;
+      ownerId: number;
+      members: MemberPerms[];
+    } | null = await prisma.collection.findUnique({
+      where: { id: currentId },
+      select: {
+        parentId: true,
+        ownerId: true,
+        members: {
+          select: {
+            userId: true,
+            canCreate: true,
+            canUpdate: true,
+            canDelete: true,
+          },
+        },
+      },
+    });
+
+    if (!col) break;
+
+    rootOwnerId = col.ownerId;
+
+    addUser({
+      userId: col.ownerId,
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+    });
+
+    for (const m of col.members) {
+      addUser(m);
+    }
+
+    currentId = col.parentId ?? null;
+  }
+
+  return {
+    rootOwnerId,
+    members: Array.from(userMap.values()),
+  };
+}

--- a/apps/web/pages/collections/[id].tsx
+++ b/apps/web/pages/collections/[id].tsx
@@ -150,7 +150,7 @@ const Page: NextPageWithLayout = () => {
                 asChild
                 variant="ghost"
                 size="icon"
-                className="mt-2 text-neutral"
+                className="mt-2 text-neutral cursor-pointer"
                 onMouseDown={(e) => e.preventDefault()}
                 title={t("more")}
               >
@@ -190,7 +190,10 @@ const Page: NextPageWithLayout = () => {
                   : t("view_team")}
               </DropdownMenuItem>
 
-              {(permissions === true || permissions?.canCreate) && (
+              {(permissions === true ||
+                (permissions?.canCreate &&
+                  permissions?.canUpdate &&
+                  permissions?.canDelete)) && (
                 <DropdownMenuItem onClick={() => setNewCollectionModal(true)}>
                   <i className="bi-folder-plus" />
                   {t("create_subcollection")}


### PR DESCRIPTION
Currently, only collection owner can create sub-collections, even though it is expected that also admins have such ability. Should solve #732 .