### PR TITLE
Android fix: Honor local trusted cert store

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -92,6 +92,7 @@ const config: ExpoConfig = {
       },
     ],
     "./plugins/with-daynight-transparent-nav",
+    "./plugins/with-network-security-config",
     "expo-font",
     "expo-web-browser",
     "expo-apple-authentication",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -81,6 +81,7 @@
         }
       ],
       "./plugins/with-daynight-transparent-nav",
+      "./plugins/with-network-security-config",
       "expo-font",
       "expo-web-browser",
       [

--- a/apps/mobile/plugins/network_security_config.xml
+++ b/apps/mobile/plugins/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/apps/mobile/plugins/with-network-security-config.js
+++ b/apps/mobile/plugins/with-network-security-config.js
@@ -1,0 +1,36 @@
+const { withAndroidManifest, withDangerousMod } = require("@expo/config-plugins");
+const path = require("path");
+const fs = require("fs");
+
+module.exports = function withNetworkSecurityConfig(config) {
+  // Copy network_security_config.xml to android/app/src/main/res/xml/
+  config = withDangerousMod(config, [
+    "android",
+    async (config) => {
+      const xmlDir = path.join(
+        config.modRequest.platformProjectRoot,
+        "app/src/main/res/xml"
+      );
+      const xmlSource = path.join(__dirname, "network_security_config.xml");
+      const xmlDest = path.join(xmlDir, "network_security_config.xml");
+
+      if (!fs.existsSync(xmlDir)) {
+        fs.mkdirSync(xmlDir, { recursive: true });
+      }
+
+      fs.copyFileSync(xmlSource, xmlDest);
+
+      return config;
+    },
+  ]);
+
+  // Add android:networkSecurityConfig to AndroidManifest.xml
+  config = withAndroidManifest(config, (config) => {
+    const mainApplication = config.modResults.manifest.application[0];
+    mainApplication.$["android:networkSecurityConfig"] =
+      "@xml/network_security_config";
+    return config;
+  });
+
+  return config;
+};


### PR DESCRIPTION
## What does this PR do?

This change resolves an issue where logging into the Android app failed with good credentials. My server has a local, LAN-only hostname with a self-signed certificate which I have added as trusted in Android. (I prefer this method + wireguard to access it from anywhere.)

- Add Android network security config to trust user-installed CA certificates, fixing self-signed certificate connections
- Implemented as an Expo config plugin that copies `network_security_config.xml` into the Android build and references it in the manifest

- Fixes #1515

## AI Assistance (Required)

We allow AI-assisted development, but reviewers need transparency to assess risk, maintainability, and correctness.

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

Claude

## What was verified by the author?

<!-- Add what you personally checked to ensure correctness and safety. -->

- [ ] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [ ] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected