### PR TITLE
fix: add default User-Agent header to safeFetch

### DIFF
--- a/packages/lib/safeFetch.ts
+++ b/packages/lib/safeFetch.ts
@@ -104,6 +104,10 @@ export async function safeFetch(
     const validatedUrl = await assertUrlIsSafeForServerSideFetch(currentUrl);
     const response = await fetch(validatedUrl.toString(), {
       ...fetchOptions,
+      headers: {
+        "User-Agent": "Linkwarden (Server-Side Fetch)",
+        ...fetchOptions.headers,
+      },
       agent: createAgent(validatedUrl),
       redirect: "manual",
     });


### PR DESCRIPTION
## What does this PR do?

`safeFetch` (introduced in v2.14.0) sends HTTP requests without a `User-Agent` header. Some servers -- notably Flipboard behind CloudFront/WAF -- reject such requests with HTTP 403, returning an HTML error page instead of the expected content. This breaks RSS feed polling (and potentially other server-side fetches).

This PR adds a default `User-Agent: Linkwarden (Server-Side Fetch)` header. Callers can still override it via `options.headers`.

## Visual Demo

N/A -- backend-only change, no UI impact.

**Before:** `safeFetch('https://flipboard.com/topic/motherhood.rss')` -> HTTP 403 + HTML error
**After:** same call -> HTTP 200 + valid RSS XML

## Verification from inside the Docker container

```bash
# Without User-Agent (current behavior) -> 403
docker exec linkwarden-linkwarden-1 node -e "
const fetch = require('node-fetch');
fetch('https://flipboard.com/topic/motherhood.rss')
  .then(r => console.log('Status:', r.status, 'Content-Type:', r.headers.get('content-type')))
"
# Status: 403 Content-Type: text/html

# With User-Agent (this fix) -> 200
docker exec linkwarden-linkwarden-1 node -e "
const fetch = require('node-fetch');
fetch('https://flipboard.com/topic/motherhood.rss', {
  headers: { 'User-Agent': 'Linkwarden (Server-Side Fetch)' }
})
  .then(r => console.log('Status:', r.status, 'Content-Type:', r.headers.get('content-type')))
"
# Status: 200 Content-Type: application/rss+xml; charset=utf-8
```

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [x] Medium (AI suggested small code changes/snippets that I adapted)
- [ ] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code (debugging, root cause analysis, fix suggestion)

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected
