### PR TITLE
fix: allow null name in UpdateUserSchema

### DIFF
--- a/packages/lib/schemaValidation.ts
+++ b/packages/lib/schemaValidation.ts
@@ -62,7 +62,7 @@ export const UpdateUserSchema = () => {
     process.env.EMAIL_FROM && process.env.EMAIL_SERVER ? true : false;
 
   return z.object({
-    name: z.string().trim().min(1).max(50).optional(),
+    name: z.string().trim().min(1).max(50).nullish(),
     email: emailEnabled
       ? z.string().trim().email().toLowerCase()
       : z.string().nullish(),


### PR DESCRIPTION
## What does this PR do?

- Fixes #1625 (GitHub issue number)

Users whose `name` is null in the database (OAuth/SSO users, or users who never set a display name) get an error when saving settings:

> Error: Invalid input: expected string, received null [name]

This also silently breaks collection sidebar reordering, because those mutations spread the full user object (`...user`) which includes `name: null`.

**Root cause:** `UpdateUserSchema` uses `.optional()` for the `name` field, which accepts `string | undefined` but rejects `null`. The Prisma schema defines `name` as `String?` (nullable), and other nullable fields in the same Zod schema (`image`, `referredBy`) already use `.nullish()`.

**Fix:** Change `.optional()` to `.nullish()` on the `name` field so that `null` passes validation. The downstream handler already null-guards with `data.name?.trim()`, so no other changes are needed.

**Before:** saving settings with `name: null` returns 400
**After:** `null` passes validation and is stored as-is in the database (which already allows it)

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [x] Medium (AI suggested small code changes/snippets that I adapted)
- [ ] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

Verified with Zod directly:
- `name: null` → now passes (was "expected string, received null")
- `name: undefined` → still passes
- `name: "John"` → still passes
- `name: ""` → still rejected by `.min(1)`
- `name` omitted → still passes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected