### PR TITLE
fix: respect user collection order in collections API

### DIFF
--- a/apps/web/lib/api/controllers/collections/getCollections.ts
+++ b/apps/web/lib/api/controllers/collections/getCollections.ts
@@ -1,35 +1,68 @@
 import { prisma } from "@linkwarden/prisma";
 
 export default async function getCollection(userId: number) {
-  const collections = await prisma.collection.findMany({
-    where: {
-      OR: [
-        { ownerId: userId },
-        { members: { some: { user: { id: userId } } } },
-      ],
-    },
-    include: {
-      _count: {
-        select: { links: true },
+  const [user, collections] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: { collectionOrder: true },
+    }),
+    prisma.collection.findMany({
+      where: {
+        OR: [
+          { ownerId: userId },
+          { members: { some: { user: { id: userId } } } },
+        ],
       },
-      parent: {
-        select: {
-          id: true,
-          name: true,
+      include: {
+        _count: {
+          select: { links: true },
         },
-      },
-      members: {
-        include: {
-          user: {
-            select: {
-              username: true,
-              name: true,
-              image: true,
+        parent: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        members: {
+          include: {
+            user: {
+              select: {
+                username: true,
+                name: true,
+                image: true,
+              },
             },
           },
         },
       },
-    },
+      orderBy: [
+        { createdAt: "asc" },
+        { id: "asc" },
+      ],
+    }),
+  ]);
+
+  const orderIndex = new Map<number, number>(
+    (user?.collectionOrder ?? []).map((id, index) => [Number(id), index])
+  );
+
+  collections.sort((a, b) => {
+    const aId = Number(a.id);
+    const bId = Number(b.id);
+    const aIndex = orderIndex.get(aId);
+    const bIndex = orderIndex.get(bId);
+
+    if (typeof aIndex === "number" && typeof bIndex === "number") {
+      return aIndex - bIndex;
+    }
+
+    if (typeof aIndex === "number") return -1;
+    if (typeof bIndex === "number") return 1;
+
+    const createdAtDiff = a.createdAt.getTime() - b.createdAt.getTime();
+    if (createdAtDiff !== 0) return createdAtDiff;
+
+    return aId - bId;
   });
 
   return { response: collections, status: 200 };


### PR DESCRIPTION
## What does this PR do?

This PR updates `/api/v1/collections` to return collections in the authenticated user's saved `collectionOrder`.

Currently, the web application applies `collectionOrder` client-side when rendering the collection tree, but API consumers receive collections in database order. This can result in a different collection order in clients that rely directly on the API, such as the mobile app.

This change:

* Retrieves the authenticated user's `collectionOrder`
* Sorts collections according to that order before returning them from the API
* Appends collections not present in `collectionOrder` using a deterministic fallback order (`createdAt`, then `id`)

No database schema changes are required.

## Visual Demo

### Before

Collections displayed in a different order in the mobile application than in the web sidebar despite having a user-defined collection order.

### After

Collections are returned from `/api/v1/collections` in the same order as the user's configured collection order, resulting in consistent ordering between web and mobile clients.

## AI Assistance (Required)

#### AI usage level (check one)

* [ ] None (no AI used)
* [ ] Light (spellcheck/rewording/comments/docs only)
* [ ] Medium (AI suggested small code changes/snippets that I adapted)
* [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

* ChatGPT

AI assistance was used to investigate the API/mobile ordering discrepancy, identify the relevant code paths, and draft the implementation. All code was reviewed, tested, and validated by the author before submission.

## What was verified by the author?

* [x] I reviewed **and** understood all AI/human generated code
* [x] I validated behavior locally (tests/manual verification)
* [x] I checked edge cases and failure modes

Validation performed:

* Confirmed the mobile application consumes `/api/v1/collections` directly.
* Verified that collections were returned out of order before the change.
* Verified that `/api/v1/collections` returns collections in `collectionOrder` after the change.
* Verified that collection ordering in the mobile application matches the web sidebar after the change.
* Verified deterministic ordering for collections not present in `collectionOrder`.

## Submission Acknowledgement

* [x] I acknowledge that a decent size PR without self-review might be rejected