### PR TITLE
Fix clipboard fallback for copy button

### DIFF
--- a/apps/web/components/CopyButton.tsx
+++ b/apps/web/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "./ui/button";
+import { copyTextToClipboard } from "@/lib/client/copyTextToClipboard";
 
 type Props = {
   text: string;
@@ -10,7 +11,12 @@ const CopyButton: React.FC<Props> = ({ text }) => {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      const copiedText = await copyTextToClipboard(text);
+
+      if (!copiedText) {
+        throw new Error("Unable to copy text to clipboard.");
+      }
+
       setCopied(true);
       setTimeout(() => {
         setCopied(false);

--- a/apps/web/lib/client/copyTextToClipboard.test.ts
+++ b/apps/web/lib/client/copyTextToClipboard.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard } from "./copyTextToClipboard";
+
+const originalExecCommand = document.execCommand;
+
+const setClipboard = (clipboard: Clipboard | undefined) => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: clipboard,
+  });
+};
+
+const setExecCommand = (result: boolean) => {
+  const execCommand = vi.fn().mockReturnValue(result);
+
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+
+  return execCommand;
+};
+
+describe("copyTextToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    setClipboard(undefined);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: originalExecCommand,
+    });
+  });
+
+  it("uses the Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText } as unknown as Clipboard);
+    const execCommand = setExecCommand(true);
+
+    await expect(copyTextToClipboard("access-token")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("access-token");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a temporary textarea when Clipboard API writes fail", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("blocked"));
+    setClipboard({ writeText } as unknown as Clipboard);
+    const execCommand = setExecCommand(true);
+
+    await expect(copyTextToClipboard("secret-token")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("secret-token");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("falls back when Clipboard API is unavailable", async () => {
+    const execCommand = setExecCommand(true);
+
+    await expect(copyTextToClipboard("plain-token")).resolves.toBe(true);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/apps/web/lib/client/copyTextToClipboard.ts
+++ b/apps/web/lib/client/copyTextToClipboard.ts
@@ -1,0 +1,38 @@
+export const copyTextToClipboard = async (text: string) => {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back for self-hosted HTTP deployments where Clipboard API calls can be blocked.
+    }
+  }
+
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const activeElement =
+    typeof HTMLElement !== "undefined" &&
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  const textArea = document.createElement("textarea");
+
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.top = "-9999px";
+  textArea.style.opacity = "0";
+
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    return document.execCommand?.("copy") ?? false;
+  } finally {
+    textArea.remove();
+    activeElement?.focus();
+  }
+};


### PR DESCRIPTION
## What does this PR do?

- Fixes #1707
- Adds a shared client copy helper that first uses `navigator.clipboard.writeText`.
- Falls back to a temporary textarea plus `document.execCommand("copy")` when the Clipboard API is unavailable or blocked, which can happen on self-hosted HTTP deployments.
- Keeps the existing copy button UI and copied-state behavior unchanged.

## Visual Demo

No visual change. The copy icon UI is unchanged; this is a behavior-only fix for clipboard writes.

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- ChatGPT

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

Verification:

- `corepack yarn test apps/web/lib/client/copyTextToClipboard.test.ts --run`
- `corepack yarn workspace @linkwarden/web exec prettier --check components/CopyButton.tsx lib/client/copyTextToClipboard.ts lib/client/copyTextToClipboard.test.ts`
- `git diff --check`
- `corepack yarn workspace @linkwarden/web exec tsc --noEmit`
- `corepack yarn workspace @linkwarden/web lint`

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected
