### PR TITLE
fix: fall back when clipboard API is unavailable

### DIFF
--- a/apps/web/components/CopyButton.tsx
+++ b/apps/web/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "./ui/button";
+import { copyTextToClipboard } from "@/lib/copyToClipboard";
 
 type Props = {
   text: string;
@@ -10,7 +11,9 @@ const CopyButton: React.FC<Props> = ({ text }) => {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      const copied = await copyTextToClipboard(text);
+      if (!copied) return;
+
       setCopied(true);
       setTimeout(() => {
         setCopied(false);

--- a/apps/web/lib/copyToClipboard.test.ts
+++ b/apps/web/lib/copyToClipboard.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  copyTextToClipboard,
+  fallbackCopyTextToClipboard,
+} from "./copyToClipboard";
+
+function mockExecCommand(result: boolean) {
+  const execCommand = vi.fn().mockReturnValue(result);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+
+  return execCommand;
+}
+
+describe("copyToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the Clipboard API when it is available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(copyTextToClipboard("token-secret")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("token-secret");
+  });
+
+  it("falls back to execCommand when the Clipboard API write fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("blocked"));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const execCommand = mockExecCommand(true);
+
+    await expect(copyTextToClipboard("token-secret")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("token-secret");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("returns false when both clipboard mechanisms are unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const execCommand = mockExecCommand(false);
+
+    await expect(copyTextToClipboard("token-secret")).resolves.toBe(false);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("cleans up the temporary textarea used by the fallback", () => {
+    const execCommand = mockExecCommand(true);
+
+    expect(fallbackCopyTextToClipboard("token-secret")).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/apps/web/lib/copyToClipboard.ts
+++ b/apps/web/lib/copyToClipboard.ts
@@ -1,0 +1,34 @@
+export function fallbackCopyTextToClipboard(text: string): boolean {
+  if (typeof document === "undefined" || !document.body) return false;
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  textArea.style.pointerEvents = "none";
+
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  textArea.setSelectionRange(0, text.length);
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    textArea.remove();
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back for insecure contexts and browsers that block Clipboard API.
+    }
+  }
+
+  return fallbackCopyTextToClipboard(text);
+}


### PR DESCRIPTION
## Summary
- add a shared clipboard helper with an execCommand fallback
- use the fallback in CopyButton so token copy still works when the Clipboard API is blocked
- add a focused regression test covering the fallback paths

## Why
Fixes #1707. Some self-hosted or non-secure browser contexts block `navigator.clipboard.writeText()`, which prevented the access-token copy button from doing anything.

## Verification
- `corepack yarn test apps/web/lib/copyToClipboard.test.ts --run`