### PR TITLE
fix(worker): let JS-rendered pages settle before readability extraction

### DIFF
--- a/apps/worker/lib/archiveHandler.ts
+++ b/apps/worker/lib/archiveHandler.ts
@@ -126,7 +126,14 @@ export default async function archiveHandler(
           await pdfHandler(link);
           return;
         } else if (link.url) {
-          await page.goto(link.url, { waitUntil: "domcontentloaded" });
+          await page.goto(link.url, { waitUntil: "domcontentloaded", timeout: 30_000 });
+          // Give JS-rendered / SPA pages a chance to populate before we snapshot
+          // the DOM for readability. Bounded + best-effort so hostile/slow sites
+          // never block the pipeline.
+          await page
+            .waitForLoadState("networkidle", { timeout: 8_000 })
+            .catch(() => {});
+          await page.waitForTimeout(700);
 
           // Handle Monolith being sent in beforehand while making sure other values line up
           if (link.monolith?.endsWith(".html")) {


### PR DESCRIPTION
Fixes #1717

## What

`archiveHandler` snapshots the page DOM via `page.content()` immediately after `domcontentloaded` and hands that HTML to Mozilla Readability. For JavaScript-rendered / SPA pages the article body usually isn't in the DOM yet at `domcontentloaded`, so Readability extracts nothing and the link ends up with empty `textContent` / `readable: "unavailable"`.

This adds a small, bounded "settle" step after navigation so client-side content has a chance to render before we snapshot it.

## How

```ts
await page.goto(link.url, { waitUntil: "domcontentloaded", timeout: 30_000 });
// give JS-rendered / SPA pages a chance to populate before snapshotting the DOM
await page.waitForLoadState("networkidle", { timeout: 8_000 }).catch(() => {});
await page.waitForTimeout(700);
```

- `goto` stays on `domcontentloaded` (fast; does not block on hostile/slow sites).
- A best-effort `networkidle` wait (8s cap, `.catch()`-guarded) lets client-side content finish loading.
- A short fixed delay covers framework hydration (React/Vue) after the network settles.

All waits are capped and swallowed, so slow or never-idle sites cannot hang or fail preservation — worst case they hit the caps and proceed exactly as before.

## Why / impact

Diagnosing a large set of links with empty `textContent` showed the failures were overwhelmingly "the page returns 200, but the DOM was snapshotted before content rendered", **not** network/IP blocks. Re-running preservation on that backlog with this change recovered **~75%** of the previously-empty links (news sites, JS-heavy blogs, etc.) with no regressions.

## Trade-off

Adds latency per link (+0.7s, up to ~8s on pages that never reach network idle). Preservation is a background job so this is usually acceptable; if it's a concern I'm happy to make the caps configurable via env vars (e.g. `PRESERVE_NETWORKIDLE_MS` / `PRESERVE_SETTLE_MS`).