### PR TITLE
fix: show direct subcollection link counts

### DIFF
--- a/apps/web/components/CollectionListing.tsx
+++ b/apps/web/components/CollectionListing.tsx
@@ -401,23 +401,6 @@ const buildTreeFromCollections = (
     });
   }
 
-  function getTotalLinkCount(collectionId: number): number {
-    const collection = items[collectionId];
-    if (!collection) {
-      return 0;
-    }
-
-    let totalLinkCount = (collection.data as any)._count?.links || 0;
-
-    if (collection.hasChildren) {
-      collection.children.forEach((childId) => {
-        totalLinkCount += getTotalLinkCount(childId as number);
-      });
-    }
-
-    return totalLinkCount;
-  }
-
   const items: { [key: string]: ExtendedTreeItem } = collections.reduce(
     (acc: any, collection) => {
       acc[collection.id as number] = {
@@ -468,14 +451,6 @@ const buildTreeFromCollections = (
     if (parentId && items[parentId] && collection.id) {
       items[parentId].children.push(collection.id);
       items[parentId].hasChildren = true;
-    }
-  });
-
-  collections.forEach((collection) => {
-    const collectionId = collection.id;
-    if (items[collectionId as number] && collection.id) {
-      const linkCount = getTotalLinkCount(collectionId as number);
-      (items[collectionId as number].data as any)._count.links = linkCount;
     }
   });
 


### PR DESCRIPTION
## Summary
- stop rolling descendant link counts into each collection in the sidebar tree
- keep each collection's displayed count aligned with its own API-provided link count

Fixes #1632.

## Verification
- corepack yarn workspace @linkwarden/web lint