### PR TITLE
fix: ignore missing local archive deletes

### DIFF
--- a/packages/filesystem/removeFile.test.ts
+++ b/packages/filesystem/removeFile.test.ts
@@ -1,0 +1,43 @@
+import fs from "fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeFile } from "./removeFile";
+
+vi.mock("fs", () => ({
+  default: {
+    unlink: vi.fn(),
+  },
+}));
+
+vi.mock("./s3Client", () => ({
+  default: null,
+}));
+
+describe("removeFile", () => {
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.STORAGE_FOLDER;
+  });
+
+  it("ignores missing local files", async () => {
+    vi.mocked(fs.unlink).mockImplementation((_path, callback) => {
+      callback({ code: "ENOENT" } as NodeJS.ErrnoException);
+    });
+
+    await removeFile({ filePath: "archives/1/2.jpg" });
+
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+
+  it("logs unexpected local delete errors", async () => {
+    const error = { code: "EACCES" } as NodeJS.ErrnoException;
+    vi.mocked(fs.unlink).mockImplementation((_path, callback) => {
+      callback(error);
+    });
+
+    await removeFile({ filePath: "archives/1/2.jpg" });
+
+    expect(consoleLog).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/filesystem/removeFile.ts
+++ b/packages/filesystem/removeFile.ts
@@ -25,7 +25,7 @@ export async function removeFile({ filePath }: { filePath: string }) {
     );
 
     fs.unlink(creationPath, (err) => {
-      if (err) console.log(err);
+      if (err && err.code !== "ENOENT") console.log(err);
     });
   }
 }


### PR DESCRIPTION
## Summary
- Ignore ENOENT when deleting local archive files so compatibility cleanup does not log errors for absent .jpg/.jpeg variants.
- Add focused coverage for missing-file deletes and unexpected delete errors.

Fixes #1695.
Supersedes #1713.

## Test
- `corepack yarn vitest run packages/filesystem/removeFile.test.ts`
