### PR TITLE
feat(mobile): trust user-installed CAs on Android (self-signed HTTPS)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -92,6 +92,7 @@ const config: ExpoConfig = {
       },
     ],
     "./plugins/with-daynight-transparent-nav",
+    "./plugins/with-android-network-security-config",
     "expo-font",
     "expo-web-browser",
     "expo-apple-authentication",

--- a/apps/mobile/plugins/with-android-network-security-config.js
+++ b/apps/mobile/plugins/with-android-network-security-config.js
@@ -1,0 +1,54 @@
+const {
+  withAndroidManifest,
+  withDangerousMod,
+  AndroidConfig,
+} = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+const FILE_NAME = "network_security_config.xml";
+
+// Trust user-installed CAs in addition to the system ones, so the app can
+// reach self-hosted instances that use a self-signed / private-CA certificate
+// once the user installs it on the device.
+// cleartextTrafficPermitted="true" preserves the existing HTTP-by-IP behavior
+// (expo-build-properties already sets usesCleartextTraffic: true).
+const XML = `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
+`;
+
+// Write the XML resource into android/app/src/main/res/xml/
+function withNetworkSecurityXmlFile(config) {
+  return withDangerousMod(config, [
+    "android",
+    async (c) => {
+      const xmlDir = path.join(
+        c.modRequest.platformProjectRoot,
+        "app/src/main/res/xml"
+      );
+      fs.mkdirSync(xmlDir, { recursive: true });
+      fs.writeFileSync(path.join(xmlDir, FILE_NAME), XML);
+      return c;
+    },
+  ]);
+}
+
+// Reference the config from the <application> tag in AndroidManifest.xml
+function withNetworkSecurityManifest(config) {
+  return withAndroidManifest(config, (c) => {
+    const app = AndroidConfig.Manifest.getMainApplicationOrThrow(c.modResults);
+    app.$["android:networkSecurityConfig"] = "@xml/network_security_config";
+    return c;
+  });
+}
+
+module.exports = function withAndroidNetworkSecurityConfig(config) {
+  return withNetworkSecurityManifest(withNetworkSecurityXmlFile(config));
+};


### PR DESCRIPTION
## Problem

On Android the mobile app cannot connect to a self-hosted instance served over HTTPS with a **self-signed / private-CA certificate**. The login just spins and eventually fails, while connecting over **HTTP by IP works fine**. This affects many self-hosters (see #1515).

### Root cause

All API calls go through the native `fetch` (OkHttp on Android), which validates TLS against the **system** trust store. Since **Android 7 (API 24)** apps do **not** trust user-installed CA certificates by default — only system ones. So even after the user installs their certificate in *Settings → Security → Install a CA certificate*, the browser trusts it but the app does not.

HTTP-by-IP works only because `expo-build-properties` already sets `usesCleartextTraffic: true`.

## Fix

Add an Expo config plugin (`plugins/with-android-network-security-config.js`) that:

- writes an Android **network security config** declaring both `system` **and** `user` trust anchors;
- references it from the `<application>` tag in `AndroidManifest.xml`.

This is the OS-level, secure approach: the user must still install their own CA on the device, and it fixes `fetch`, the WebView (page/PDF previews) and file downloads at once — not just `fetch`. No MITM is silently allowed; only certificates the user explicitly installs are trusted.

`cleartextTrafficPermitted="true"` is preserved in the config so the existing HTTP-by-IP behavior is unchanged.

## Changes

- **new** `apps/mobile/plugins/with-android-network-security-config.js` — the config plugin
- `apps/mobile/app.config.ts` — register the plugin in the `plugins` array

## Prior art / credit

This is the same fix as #1652 by @djthread (thank you! 🙏), which first tackled #1515 with an identical Android network security config (`system` + `user` trust anchors). That PR has gone stale and is now **conflicting** with `dev`: it edits `apps/mobile/app.json`, which has since been migrated to `apps/mobile/app.config.ts`, so it no longer applies cleanly. This PR rebases the same approach onto the current `dev` so it merges without conflicts. Happy to close this in favor of #1652 if the maintainers would rather revive that one.

## Notes / testing

Requires a native rebuild (`npx expo prebuild --clean` + a dev/EAS build — not Expo Go). After installing the CA on the device, HTTPS with the self-signed certificate connects successfully. iOS already allows this via `NSAllowsArbitraryLoads`; this brings Android in line for user-trusted CAs.

Closes #1515