### PR TITLE
fix(worker): replace page.goBack() with page.goto(link.url) to avoid timeout on redirect chains

### DIFF
--- a/apps/worker/lib/preservationScheme/handleArchivePreview.ts
+++ b/apps/worker/lib/preservationScheme/handleArchivePreview.ts
@@ -48,7 +48,9 @@ const handleArchivePreview = async (
         );
       }
 
-      await page.goBack();
+      // Use page.goto instead of page.goBack to avoid timeouts on
+      // sites with redirect chains (e.g. tracking redirects).
+      await page.goto(link.url);
     } catch (error) {
       if (!(error instanceof UnsafeUrlError)) {
         throw error;


### PR DESCRIPTION
## What does this PR do?

The archiver worker's \handleArchivePreview.ts\ uses \page.goBack()\ after fetching the OG image. On sites with redirect chains (e.g. tracking redirects, affiliate links), the browser's history stack includes intermediate redirect URLs. Navigating back through these with \goBack()\ causes the worker to time out.

Replacing with \page.goto(link.url)\ navigates directly to the original link URL without relying on the history stack — deterministic and avoids the timeout.

- Fixes #1744

## Visual Demo

Not applicable — this is a server-side worker behavior change (no UI). The fix was verified in a local deployment: previously-stuck links now archive successfully.

## AI Assistance (Required)

- [x] Medium (AI suggested the code change that I reviewed and adapted)
- Tool: Claude via opencode

## What was verified by the author?

- [x] I reviewed and understood all AI/human generated code
- [x] I validated behavior locally (tested with previously-failing URLs)
- [x] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected