### PR TITLE
fix: cache validated DNS resolutions and reuse fetch agents in safeFetch

### DIFF
--- a/packages/lib/safeFetch.ts
+++ b/packages/lib/safeFetch.ts
@@ -56,36 +56,62 @@ function createSafeLookup() {
   return lookup;
 }
 
+// Agents are cached at module level so connections are reused across
+// requests (keep-alive). Creating a new Agent per request forces a fresh
+// TCP+TLS handshake for every fetch, which on pages with dozens of
+// subresources adds 15-25s and pushes page.goto past its navigation
+// timeout. Connection reuse also cannot be affected by DNS rebinding,
+// since no re-resolution happens on a reused socket.
+let cachedProxyAgent: HttpsProxyAgent<string> | SocksProxyAgent | undefined;
+let cachedHttpAgent: http.Agent | undefined;
+let cachedHttpsAgent: https.Agent | undefined;
+
 function createAgent(target: URL) {
   if (process.env.PROXY) {
-    const proxy = new URL(process.env.PROXY);
+    if (!cachedProxyAgent) {
+      const proxy = new URL(process.env.PROXY);
 
-    if (process.env.PROXY_USERNAME) {
-      proxy.username = process.env.PROXY_USERNAME;
-      proxy.password = process.env.PROXY_PASSWORD || "";
+      if (process.env.PROXY_USERNAME) {
+        proxy.username = process.env.PROXY_USERNAME;
+        proxy.password = process.env.PROXY_PASSWORD || "";
+      }
+
+      const ProxyAgent = proxy.protocol.includes("http")
+        ? HttpsProxyAgent
+        : SocksProxyAgent;
+
+      cachedProxyAgent = new ProxyAgent(proxy.toString());
     }
 
-    const ProxyAgent = proxy.protocol.includes("http")
-      ? HttpsProxyAgent
-      : SocksProxyAgent;
-
-    return new ProxyAgent(proxy.toString());
+    return cachedProxyAgent;
   }
-
-  const lookup = createSafeLookup();
 
   if (target.protocol === "http:") {
-    return new http.Agent({ lookup });
+    if (!cachedHttpAgent) {
+      cachedHttpAgent = new http.Agent({
+        lookup: createSafeLookup(),
+        keepAlive: true,
+        maxSockets: 8,
+      });
+    }
+
+    return cachedHttpAgent;
   }
 
-  return new https.Agent({
-    lookup,
-    rejectUnauthorized:
-      process.env.ALLOW_INSECURE_TLS === "true" ||
-      process.env.IGNORE_UNAUTHORIZED_CA === "true"
-        ? false
-        : true,
-  });
+  if (!cachedHttpsAgent) {
+    cachedHttpsAgent = new https.Agent({
+      lookup: createSafeLookup(),
+      keepAlive: true,
+      maxSockets: 8,
+      rejectUnauthorized:
+        process.env.ALLOW_INSECURE_TLS === "true" ||
+        process.env.IGNORE_UNAUTHORIZED_CA === "true"
+          ? false
+          : true,
+    });
+  }
+
+  return cachedHttpsAgent;
 }
 
 function isRedirectStatus(status: number) {

--- a/packages/lib/ssrf.ts
+++ b/packages/lib/ssrf.ts
@@ -256,6 +256,24 @@ export const defaultHostnameLookup: HostnameLookup = async (hostname) => {
     }));
 };
 
+// Successful resolutions through the default lookup are cached for a short
+// TTL, and concurrent lookups for the same hostname share one in-flight
+// promise. Archiving a single page can trigger dozens of lookups for the
+// same few hostnames (one per request plus one per new socket); without a
+// cache this bursts the local resolver, and rate-limiting resolvers (e.g.
+// AdGuard Home with its default ratelimit of 20 qps) start dropping
+// queries, stalling page loads on multi-second OS retry timeouts until
+// page.goto exceeds its navigation timeout. Serving a pinned,
+// already-validated result during the TTL also cannot be affected by DNS
+// rebinding, since no re-resolution happens while it is served.
+const RESOLVE_CACHE_TTL_MS = 30_000;
+const RESOLVE_CACHE_MAX_ENTRIES = 512;
+
+const resolveCache = new Map<
+  string,
+  { expires: number; promise: Promise<ReadonlyArray<ResolvedAddress>> }
+>();
+
 export async function resolveHostnameForServerSideFetch(
   hostname: string,
   lookup: HostnameLookup = defaultHostnameLookup
@@ -276,6 +294,38 @@ export async function resolveHostnameForServerSideFetch(
     return [{ address: normalized, family: ipFamily }] as const;
   }
 
+  // Custom lookups (used by tests) bypass the cache.
+  if (lookup !== defaultHostnameLookup) {
+    return resolveAndValidateHostname(normalized, lookup);
+  }
+
+  const cached = resolveCache.get(normalized);
+
+  if (cached && cached.expires > Date.now()) {
+    return cached.promise;
+  }
+
+  const promise = resolveAndValidateHostname(normalized, lookup);
+
+  resolveCache.set(normalized, {
+    expires: Date.now() + RESOLVE_CACHE_TTL_MS,
+    promise,
+  });
+
+  promise.catch(() => resolveCache.delete(normalized));
+
+  if (resolveCache.size > RESOLVE_CACHE_MAX_ENTRIES) {
+    const oldest = resolveCache.keys().next().value;
+    if (oldest !== undefined) resolveCache.delete(oldest);
+  }
+
+  return promise;
+}
+
+async function resolveAndValidateHostname(
+  normalized: string,
+  lookup: HostnameLookup
+) {
   let addresses: ReadonlyArray<ResolvedAddress>;
 
   try {


### PR DESCRIPTION
Fixes #1747

Archiving pages with many subresources fails with `page.goto: Timeout 30000ms exceeded` because `safeFetch` performs at least two uncached DNS lookups per intercepted request (one in `assertUrlIsSafeForServerSideFetch`, one in the agent lookup for every new socket) and creates a new Agent per request and per redirect hop, so connections are never reused. On rate-limiting resolvers (AdGuard Home ships with `ratelimit: 20` by default) the burst gets dropped and getaddrinfo stalls on multi-second retry timeouts. Full analysis and measurements are in the issue.

**Changes**

- `packages/lib/ssrf.ts`: successful resolutions through the default lookup are cached for 30s, and concurrent lookups for the same hostname share one in-flight promise. Failed resolutions are not cached. Custom lookups (used by the tests) bypass the cache. Rebinding protection stays intact: during the TTL a pinned, already-validated result is served and no re-resolution happens.
- `packages/lib/safeFetch.ts`: http, https and proxy agents are cached at module level with keep-alive and a per-host socket cap, instead of being created per request.

**Validation** (live v2.15.1 instance, docker, resolver rate limit left in place)

- before: GitHub repo pages consistently fail with the navigation timeout; 24 parallel safeFetch calls take 8-12s each, with latencies quantized in 4s steps
- after: the same page preserves completely (screenshot, PDF, monolith, readable and text content)

Happy to adjust the TTL, cache size or socket cap if you prefer different values.