### PR TITLE
fix: resolve protocol-relative preview URLs

### DIFF
--- a/apps/worker/lib/preservationScheme/handleArchivePreview.ts
+++ b/apps/worker/lib/preservationScheme/handleArchivePreview.ts
@@ -5,6 +5,7 @@ import { createFile } from "@linkwarden/filesystem";
 import { prisma } from "@linkwarden/prisma";
 import { safeFetch } from "@linkwarden/lib/safeFetch";
 import { UnsafeUrlError } from "@linkwarden/lib/ssrf";
+import { resolvePageAssetUrl } from "./resolvePageAssetUrl";
 
 type LinksAndCollectionAndOwner = Link & {
   collection: Collection & {
@@ -24,16 +25,10 @@ const handleArchivePreview = async (
   let previewGenerated = false;
 
   if (ogImageUrl && !link.preview?.startsWith("archive")) {
-    if (
-      !ogImageUrl.startsWith("http://") &&
-      !ogImageUrl.startsWith("https://")
-    ) {
-      const origin = await page.evaluate(() => document.location.origin);
-      ogImageUrl =
-        origin + (ogImageUrl.startsWith("/") ? ogImageUrl : "/" + ogImageUrl);
-    }
-
     try {
+      const origin = await page.evaluate(() => document.location.origin);
+      ogImageUrl = resolvePageAssetUrl(ogImageUrl, origin);
+
       const imageResponse = await safeFetch(ogImageUrl);
 
       if (imageResponse.ok) {
@@ -46,7 +41,7 @@ const handleArchivePreview = async (
       }
     } catch (error) {
       if (!(error instanceof UnsafeUrlError)) {
-        throw error;
+        console.warn("Unable to generate preview from page metadata", error);
       }
     }
   }

--- a/apps/worker/lib/preservationScheme/resolvePageAssetUrl.test.ts
+++ b/apps/worker/lib/preservationScheme/resolvePageAssetUrl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolvePageAssetUrl } from "./resolvePageAssetUrl";
+
+describe("resolvePageAssetUrl", () => {
+  const pageOrigin = "https://space.bilibili.com";
+
+  it("resolves a protocol-relative URL using the page protocol", () => {
+    expect(
+      resolvePageAssetUrl("//www.bilibili.com/favicon.ico", pageOrigin)
+    ).toBe("https://www.bilibili.com/favicon.ico");
+  });
+
+  it("resolves a root-relative URL using the page origin", () => {
+    expect(resolvePageAssetUrl("/favicon.ico", pageOrigin)).toBe(
+      "https://space.bilibili.com/favicon.ico"
+    );
+  });
+
+  it("keeps an absolute URL unchanged", () => {
+    expect(
+      resolvePageAssetUrl("https://cdn.example.com/preview.png", pageOrigin)
+    ).toBe("https://cdn.example.com/preview.png");
+  });
+});

--- a/apps/worker/lib/preservationScheme/resolvePageAssetUrl.ts
+++ b/apps/worker/lib/preservationScheme/resolvePageAssetUrl.ts
@@ -1,0 +1,2 @@
+export const resolvePageAssetUrl = (assetUrl: string, pageOrigin: string) =>
+  new URL(assetUrl, pageOrigin).toString();


### PR DESCRIPTION
## What
- Resolve preview asset URLs with the standard URL parser, including protocol-relative URLs.
- Fall back to screenshot generation when metadata preview fetching fails.
- Add regression coverage for protocol-relative, root-relative, and absolute URLs.

## Why
Manually joining the page origin produced malformed URLs such as https://space.bilibili.com//www.bilibili.com/favicon.ico and could abort preservation.

Closes #1738

## Checks
- yarn test apps/worker/lib/preservationScheme/resolvePageAssetUrl.test.ts --run (3 tests passed)
- yarn workspace @linkwarden/worker typecheck
- Prettier check on changed files