### PR TITLE
feat: resume reading position in readable view

### DIFF
--- a/apps/mobile/components/Formats/ReadableFormat.tsx
+++ b/apps/mobile/components/Formats/ReadableFormat.tsx
@@ -294,11 +294,11 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
 
     const { data: user } = useUser(auth);
     const readingProgressEnabled = user?.readingProgressEnabled ?? false;
-    const { data: savedReadingProgress } = useGetReadingProgress(
-      link.id,
-      auth,
-      readingProgressEnabled
-    );
+    const {
+      data: savedReadingProgress,
+      isFetchedAfterMount: progressIsFresh,
+      isError: progressFetchFailed,
+    } = useGetReadingProgress(link.id, auth, readingProgressEnabled);
     const updateReadingProgress = useUpdateReadingProgress(link.id, auth);
     const hasRestoredProgressRef = useRef(false);
     const latestProgressRef = useRef<number | null>(null);
@@ -449,15 +449,23 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
     }, [readingProgressEnabled, restoreReadingProgressInWebView]);
 
     useEffect(() => {
+      // Only trust this mount's fetch — another device may have moved the
+      // position since the query cache was written. Fall back to the cache
+      // when the fetch fails (e.g. offline).
       if (
-        savedReadingProgress !== undefined &&
+        (progressIsFresh || progressFetchFailed) &&
         latestProgressRef.current === null
       ) {
         latestProgressRef.current = savedReadingProgress ?? 0;
       }
       // Also retries when the user preference loads after the WebView is ready
       flushProgressRestore();
-    }, [savedReadingProgress, flushProgressRestore]);
+    }, [
+      savedReadingProgress,
+      progressIsFresh,
+      progressFetchFailed,
+      flushProgressRestore,
+    ]);
 
     const readerStyleConfig = useMemo(
       () =>

--- a/apps/mobile/components/Formats/ReadableFormat.tsx
+++ b/apps/mobile/components/Formats/ReadableFormat.tsx
@@ -29,6 +29,11 @@ import {
   ReadableHighlightDraft,
 } from "@/components/ActionSheets/ReadableHighlightSheet";
 import { useGetLinkHighlights } from "@linkwarden/router/highlights";
+import { useUser } from "@linkwarden/router/user";
+import {
+  useGetReadingProgress,
+  useUpdateReadingProgress,
+} from "@linkwarden/router/readingProgress";
 import useReaderStore, {
   getReadableFontFamily,
   resolveReaderTheme,
@@ -287,6 +292,17 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
 
     const { data: linkHighlights = [] } = useGetLinkHighlights(link.id, auth);
 
+    const { data: user } = useUser(auth);
+    const readingProgressEnabled = user?.readingProgressEnabled ?? false;
+    const { data: savedReadingProgress } = useGetReadingProgress(
+      link.id,
+      auth,
+      readingProgressEnabled
+    );
+    const updateReadingProgress = useUpdateReadingProgress(link.id, auth);
+    const hasRestoredProgressRef = useRef(false);
+    const latestProgressRef = useRef<number | null>(null);
+
     const clearWebSelection = useCallback(() => {
       pendingSelectionTextRef.current = null;
 
@@ -405,6 +421,43 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
       true;
     `);
     }, []);
+
+    const restoreReadingProgressInWebView = useCallback((progress: number) => {
+      if (!isWebViewReadyRef.current) return;
+
+      webViewRef.current?.injectJavaScript(`
+      if (window.__READABLE_VIEW__?.restoreReadingProgress) {
+        window.__READABLE_VIEW__.restoreReadingProgress(${progress});
+      }
+      true;
+    `);
+    }, []);
+
+    const flushProgressRestore = useCallback(() => {
+      if (
+        !isWebViewReadyRef.current ||
+        hasRestoredProgressRef.current ||
+        !readingProgressEnabled ||
+        latestProgressRef.current === null
+      )
+        return;
+
+      if (latestProgressRef.current > 0) {
+        restoreReadingProgressInWebView(latestProgressRef.current);
+      }
+      hasRestoredProgressRef.current = true;
+    }, [readingProgressEnabled, restoreReadingProgressInWebView]);
+
+    useEffect(() => {
+      if (
+        savedReadingProgress !== undefined &&
+        latestProgressRef.current === null
+      ) {
+        latestProgressRef.current = savedReadingProgress ?? 0;
+      }
+      // Also retries when the user preference loads after the WebView is ready
+      flushProgressRestore();
+    }, [savedReadingProgress, flushProgressRestore]);
 
     const readerStyleConfig = useMemo(
       () =>
@@ -947,12 +1000,54 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
             postMessage("highlight-press", highlight);
           });
 
+          let scrollProgressTimeout = null;
+
+          function restoreReadingProgress(progress) {
+            let lastHeight = -1;
+            let attempts = 0;
+            const interval = setInterval(function () {
+              attempts++;
+              if (attempts > 40) {
+                clearInterval(interval);
+                return;
+              }
+              // wait until the layout has settled before scrolling
+              const height = document.documentElement.scrollHeight;
+              if (height !== lastHeight) {
+                lastHeight = height;
+                return;
+              }
+              clearInterval(interval);
+              const maxScroll = height - window.innerHeight;
+              if (maxScroll > 0) window.scrollTo(0, progress * maxScroll);
+            }, 250);
+          }
+
+          window.addEventListener(
+            "scroll",
+            function () {
+              if (scrollProgressTimeout) clearTimeout(scrollProgressTimeout);
+              scrollProgressTimeout = setTimeout(function () {
+                const maxScroll =
+                  document.documentElement.scrollHeight - window.innerHeight;
+                if (maxScroll <= 0) return;
+                const progress = Math.min(
+                  Math.max(window.scrollY / maxScroll, 0),
+                  1
+                );
+                postMessage("scroll-progress", progress);
+              }, 500);
+            },
+            { passive: true }
+          );
+
           window.__READABLE_VIEW__ = {
             applyReaderStyles: applyReaderStyles,
             clearSelection: clearSelection,
             getSelectionInfo: getSelectionInfo,
             renderHighlights: renderHighlights,
             scrollToHighlight: scrollToHighlight,
+            restoreReadingProgress: restoreReadingProgress,
           };
 
           applyReaderStyles(initialReaderStyles);
@@ -1045,9 +1140,26 @@ const ReadableFormat = forwardRef<ReadableFormatRef, Props>(
 
       if (message?.type === "ready") {
         isWebViewReadyRef.current = true;
+        const hadPendingHighlightScroll =
+          pendingHighlightScrollIdRef.current !== null;
         syncReaderStylesToWebView(readerStyleConfig);
         syncHighlightsToWebView(linkHighlights);
         flushPendingHighlightScroll();
+        // The document is rebuilt from scratch, so the position needs to be
+        // restored again — unless a highlight scroll takes precedence.
+        hasRestoredProgressRef.current = hadPendingHighlightScroll;
+        flushProgressRestore();
+        return;
+      }
+
+      if (
+        message?.type === "scroll-progress" &&
+        typeof message.payload === "number"
+      ) {
+        // Don't overwrite the saved progress before it was restored
+        if (!readingProgressEnabled || !hasRestoredProgressRef.current) return;
+        latestProgressRef.current = message.payload;
+        updateReadingProgress.mutate(message.payload);
         return;
       }
 

--- a/apps/web/components/Preservation/PreservationPageContent.tsx
+++ b/apps/web/components/Preservation/PreservationPageContent.tsx
@@ -30,11 +30,11 @@ export default function PreservationPageContent() {
     Number(router.query.format) === ArchivedFormat.readability &&
     (user?.readingProgressEnabled ?? false);
 
-  const { data: savedProgress } = useGetReadingProgress(
-    link?.id,
-    undefined,
-    trackReadingProgress
-  );
+  const {
+    data: savedProgress,
+    isFetchedAfterMount: progressIsFresh,
+    isError: progressFetchFailed,
+  } = useGetReadingProgress(link?.id, undefined, trackReadingProgress);
   const updateReadingProgress = useUpdateReadingProgress(link?.id);
   const restoredRef = useRef(false);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -43,10 +43,13 @@ export default function PreservationPageContent() {
   // layout has settled (content height can grow while highlights and reader
   // styles are applied).
   useEffect(() => {
+    // Only trust this mount's fetch — another device may have moved the
+    // position since the query cache was written. Fall back to the cache
+    // when the fetch fails.
     if (
       !trackReadingProgress ||
       restoredRef.current ||
-      savedProgress === undefined
+      !(progressIsFresh || progressFetchFailed)
     )
       return;
 
@@ -79,7 +82,12 @@ export default function PreservationPageContent() {
       clearInterval(interval);
       clearTimeout(timeout);
     };
-  }, [trackReadingProgress, savedProgress]);
+  }, [
+    trackReadingProgress,
+    savedProgress,
+    progressIsFresh,
+    progressFetchFailed,
+  ]);
 
   const handleScroll = () => {
     // Don't overwrite the saved progress before it was restored

--- a/apps/web/components/Preservation/PreservationPageContent.tsx
+++ b/apps/web/components/Preservation/PreservationPageContent.tsx
@@ -1,6 +1,12 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { useGetLink } from "@linkwarden/router/links";
+import { useUser } from "@linkwarden/router/user";
+import {
+  useGetReadingProgress,
+  useUpdateReadingProgress,
+} from "@linkwarden/router/readingProgress";
+import { ArchivedFormat } from "@linkwarden/types/global";
 import { PreservationContent } from "./PreservationContent";
 import PreservationNavbar from "./PreservationNavbar";
 
@@ -17,6 +23,87 @@ export default function PreservationPageContent() {
     enabled: true,
   });
 
+  const { data: user } = useUser();
+
+  const trackReadingProgress =
+    !isPublicRoute &&
+    Number(router.query.format) === ArchivedFormat.readability &&
+    (user?.readingProgressEnabled ?? false);
+
+  const { data: savedProgress } = useGetReadingProgress(
+    link?.id,
+    undefined,
+    trackReadingProgress
+  );
+  const updateReadingProgress = useUpdateReadingProgress(link?.id);
+  const restoredRef = useRef(false);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Restore the saved position once the readable content is rendered and its
+  // layout has settled (content height can grow while highlights and reader
+  // styles are applied).
+  useEffect(() => {
+    if (
+      !trackReadingProgress ||
+      restoredRef.current ||
+      savedProgress === undefined
+    )
+      return;
+
+    if (!savedProgress) {
+      restoredRef.current = true;
+      return;
+    }
+
+    let lastHeight = -1;
+    const interval = setInterval(() => {
+      const element = scrollRef.current;
+      if (!element || !document.getElementById("readable-view")) return;
+
+      if (element.scrollHeight !== lastHeight) {
+        lastHeight = element.scrollHeight;
+        return;
+      }
+
+      const maxScroll = element.scrollHeight - element.clientHeight;
+      if (maxScroll <= 0) return;
+
+      element.scrollTop = savedProgress * maxScroll;
+      restoredRef.current = true;
+      clearInterval(interval);
+    }, 250);
+
+    const timeout = setTimeout(() => clearInterval(interval), 15000);
+
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timeout);
+    };
+  }, [trackReadingProgress, savedProgress]);
+
+  const handleScroll = () => {
+    // Don't overwrite the saved progress before it was restored
+    if (!trackReadingProgress || !restoredRef.current) return;
+
+    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    saveTimeoutRef.current = setTimeout(() => {
+      const element = scrollRef.current;
+      if (!element) return;
+
+      const maxScroll = element.scrollHeight - element.clientHeight;
+      if (maxScroll <= 0) return;
+
+      const progress = Math.min(Math.max(element.scrollTop / maxScroll, 0), 1);
+      updateReadingProgress.mutate(progress);
+    }, 1000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    };
+  }, []);
+
   return (
     <div>
       {link?.id && (
@@ -25,6 +112,7 @@ export default function PreservationPageContent() {
       <div
         className={`bg-base-200 overflow-y-auto w-screen h-[calc(100vh-3.1rem)] mt-[3.1rem]`}
         ref={scrollRef}
+        onScroll={handleScroll}
       >
         <PreservationContent link={link} format={Number(router.query.format)} />
       </div>

--- a/apps/web/lib/api/controllers/links/linkId/readingProgress/getReadingProgress.ts
+++ b/apps/web/lib/api/controllers/links/linkId/readingProgress/getReadingProgress.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@linkwarden/prisma";
+
+export default async function getReadingProgress({
+  userId,
+  linkId,
+}: {
+  userId: number;
+  linkId: number;
+}) {
+  const readingProgress = await prisma.readingProgress.findUnique({
+    where: {
+      linkId_userId: {
+        linkId,
+        userId,
+      },
+    },
+  });
+
+  return { response: readingProgress?.progress ?? null, status: 200 };
+}

--- a/apps/web/lib/api/controllers/links/linkId/readingProgress/upsertReadingProgress.ts
+++ b/apps/web/lib/api/controllers/links/linkId/readingProgress/upsertReadingProgress.ts
@@ -1,0 +1,71 @@
+import { prisma } from "@linkwarden/prisma";
+import {
+  UpsertReadingProgressSchema,
+  UpsertReadingProgressSchemaType,
+} from "@linkwarden/lib/schemaValidation";
+
+export default async function upsertReadingProgress(
+  userId: number,
+  linkId: number,
+  body: UpsertReadingProgressSchemaType
+) {
+  const dataValidation = UpsertReadingProgressSchema.safeParse(body);
+
+  if (!dataValidation.success) {
+    return {
+      response: `Error: ${
+        dataValidation.error.issues[0].message
+      } [${dataValidation.error.issues[0].path.join(", ")}]`,
+      status: 400,
+    };
+  }
+
+  const { progress } = dataValidation.data;
+
+  // check if user has access to the link's collection
+  const collection = await prisma.collection.findFirst({
+    where: {
+      links: {
+        some: {
+          id: linkId,
+        },
+      },
+    },
+    include: {
+      members: true,
+    },
+  });
+
+  if (
+    !collection ||
+    (!collection.members.some((m) => m.userId === userId) &&
+      !(collection.ownerId === userId))
+  ) {
+    return {
+      status: 400,
+      response: "Collection not accessible",
+    };
+  }
+
+  const readingProgress = await prisma.readingProgress.upsert({
+    where: {
+      linkId_userId: {
+        linkId,
+        userId,
+      },
+    },
+    update: {
+      progress,
+    },
+    create: {
+      userId,
+      linkId,
+      progress,
+    },
+  });
+
+  return {
+    status: 200,
+    response: readingProgress,
+  };
+}

--- a/apps/web/lib/api/controllers/users/userId/updateUserById.ts
+++ b/apps/web/lib/api/controllers/users/userId/updateUserById.ts
@@ -223,6 +223,7 @@ export default async function updateUserById(
       archiveAsWaybackMachine: data.archiveAsWaybackMachine,
       linksRouteTo: data.linksRouteTo,
       preventDuplicateLinks: data.preventDuplicateLinks,
+      readingProgressEnabled: data.readingProgressEnabled,
       referredBy:
         !user?.referredBy && data.referredBy ? data.referredBy : undefined,
       password:

--- a/apps/web/pages/api/v1/links/[id]/progress/index.ts
+++ b/apps/web/pages/api/v1/links/[id]/progress/index.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import verifyUser from "@/lib/api/verifyUser";
+import getReadingProgress from "@/lib/api/controllers/links/linkId/readingProgress/getReadingProgress";
+import upsertReadingProgress from "@/lib/api/controllers/links/linkId/readingProgress/upsertReadingProgress";
+
+export default async function progress(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const user = await verifyUser({ req, res });
+  if (!user) return;
+
+  const linkId = Number(req.query.id as string);
+
+  if (req.method === "GET") {
+    if (!user.readingProgressEnabled)
+      return res.status(200).json({ response: null });
+
+    const readingProgress = await getReadingProgress({
+      userId: user.id,
+      linkId,
+    });
+
+    return res
+      .status(readingProgress?.status || 500)
+      .json({ response: readingProgress?.response });
+  } else if (req.method === "PUT") {
+    if (process.env.NEXT_PUBLIC_DEMO === "true")
+      return res.status(400).json({
+        response:
+          "This action is disabled because this is a read-only demo of Linkwarden.",
+      });
+
+    if (!user.readingProgressEnabled)
+      return res.status(200).json({ response: null });
+
+    const updated = await upsertReadingProgress(user.id, linkId, req.body);
+
+    return res
+      .status(updated?.status || 500)
+      .json({ response: updated?.response });
+  }
+}

--- a/apps/web/pages/settings/preference.tsx
+++ b/apps/web/pages/settings/preference.tsx
@@ -53,6 +53,9 @@ const Page: NextPageWithLayout = () => {
   const [preventDuplicateLinks, setPreventDuplicateLinks] = useState<boolean>(
     account.preventDuplicateLinks || false
   );
+  const [readingProgressEnabled, setReadingProgressEnabled] = useState<boolean>(
+    account.readingProgressEnabled ?? true
+  );
   const [archiveAsScreenshot, setArchiveAsScreenshot] = useState<boolean>(
     account.archiveAsScreenshot || false
   );
@@ -89,6 +92,7 @@ const Page: NextPageWithLayout = () => {
       setArchiveAsWaybackMachine(account.archiveAsWaybackMachine ?? false);
       setLinksRouteTo(account.linksRouteTo);
       setPreventDuplicateLinks(account.preventDuplicateLinks ?? false);
+      setReadingProgressEnabled(account.readingProgressEnabled ?? true);
       setAiTaggingMethod(account.aiTaggingMethod);
       setAiPredefinedTags(account.aiPredefinedTags);
       setAiTagExistingLinks(account.aiTagExistingLinks ?? false);
@@ -148,6 +152,7 @@ const Page: NextPageWithLayout = () => {
   const hasLinkChanges =
     !!account?.id &&
     (preventDuplicateLinks !== (account.preventDuplicateLinks ?? false) ||
+      readingProgressEnabled !== (account.readingProgressEnabled ?? true) ||
       linksRouteTo !== account.linksRouteTo);
 
   const saveAiSection = async () => {
@@ -226,6 +231,7 @@ const Page: NextPageWithLayout = () => {
       await updateUser.mutateAsync({
         ...baseUserPayload(),
         preventDuplicateLinks,
+        readingProgressEnabled,
         linksRouteTo,
       });
 
@@ -595,6 +601,13 @@ const Page: NextPageWithLayout = () => {
               label={t("prevent_duplicate_links")}
               state={preventDuplicateLinks}
               onClick={() => setPreventDuplicateLinks(!preventDuplicateLinks)}
+            />
+          </div>
+          <div className="mb-3">
+            <Checkbox
+              label={t("save_reading_progress")}
+              state={readingProgressEnabled}
+              onClick={() => setReadingProgressEnabled(!readingProgressEnabled)}
             />
           </div>
           <p>{t("clicking_on_links_should")}</p>

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -174,6 +174,7 @@
   "archive_org_snapshot": "Archive.org Snapshot",
   "link_settings": "Link Settings",
   "prevent_duplicate_links": "Prevent duplicate links",
+  "save_reading_progress": "Save reading progress (resume articles where you left off)",
   "clicking_on_links_should": "Clicking on Links should:",
   "open_original_content": "Open the original content",
   "open_pdf_if_available": "Open PDF, if available",

--- a/packages/lib/schemaValidation.ts
+++ b/packages/lib/schemaValidation.ts
@@ -88,6 +88,7 @@ export const UpdateUserSchema = () => {
     locale: z.string().max(20).optional(),
     isPrivate: z.boolean().optional(),
     preventDuplicateLinks: z.boolean().optional(),
+    readingProgressEnabled: z.boolean().optional(),
     collectionOrder: z.array(z.number()).optional(),
     linksRouteTo: z.enum(LinksRouteTo).optional(),
     referredBy: z.string().max(100).nullish(),
@@ -114,6 +115,14 @@ export const UpdateUserPreferenceSchema = z.object({
 
 export type UpdateUserPreferenceSchemaType = z.infer<
   typeof UpdateUserPreferenceSchema
+>;
+
+export const UpsertReadingProgressSchema = z.object({
+  progress: z.number().min(0).max(1),
+});
+
+export type UpsertReadingProgressSchemaType = z.infer<
+  typeof UpsertReadingProgressSchema
 >;
 
 export const PostSessionSchema = z.object({

--- a/packages/prisma/migrations/20260728114732_add_reading_progress/migration.sql
+++ b/packages/prisma/migrations/20260728114732_add_reading_progress/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "readingProgressEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "ReadingProgress" (
+    "id" SERIAL NOT NULL,
+    "linkId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "progress" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReadingProgress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReadingProgress_linkId_userId_key" ON "ReadingProgress"("linkId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "ReadingProgress" ADD CONSTRAINT "ReadingProgress_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReadingProgress" ADD CONSTRAINT "ReadingProgress_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   createdLinks            Link[]                @relation("CreatedLinks")
   createdCollections      Collection[]          @relation("CreatedCollections")
   highlights              Highlight[]
+  readingProgress         ReadingProgress[]
   collectionsJoined       UsersAndCollections[]
   collectionOrder         Int[]                 @default([])
   whitelistedUsers        WhitelistedUser[]
@@ -60,6 +61,7 @@ model User {
   readableLineHeight      String?               @default("1.8")
   readableLineWidth       String?               @default("normal")
   preventDuplicateLinks   Boolean               @default(false)
+  readingProgressEnabled  Boolean               @default(true)
   archiveAsScreenshot     Boolean               @default(true)
   archiveAsMonolith       Boolean               @default(true)
   archiveAsPDF            Boolean               @default(true)
@@ -170,6 +172,7 @@ model Link {
   type            String      @default("url")
   description     String      @default("")
   highlight       Highlight[]
+  readingProgress ReadingProgress[]
   pinnedBy        User[]      @relation("PinnedLinks")
   createdBy       User?       @relation("CreatedLinks", fields: [createdById], references: [id], onDelete: Cascade)
   createdById     Int?
@@ -285,6 +288,19 @@ model Highlight {
   text        String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @default(now()) @updatedAt
+}
+
+model ReadingProgress {
+  id        Int      @id @default(autoincrement())
+  link      Link     @relation(fields: [linkId], references: [id], onDelete: Cascade)
+  linkId    Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    Int
+  progress  Float    @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([linkId, userId])
 }
 
 model DashboardSection {

--- a/packages/router/readingProgress.tsx
+++ b/packages/router/readingProgress.tsx
@@ -40,6 +40,10 @@ const useGetReadingProgress = (
       const data = await response.json();
       return (data.response as number | null) ?? null;
     },
+    // The position can change from other devices at any time, so the cached
+    // value can't be trusted on mount.
+    staleTime: 0,
+    refetchOnMount: "always",
     enabled: status === "authenticated" && !!linkId && enabled,
   });
 };

--- a/packages/router/readingProgress.tsx
+++ b/packages/router/readingProgress.tsx
@@ -1,0 +1,78 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import { MobileAuth } from "@linkwarden/types/global";
+
+const useGetReadingProgress = (
+  linkId?: number,
+  auth?: MobileAuth,
+  enabled = true
+): UseQueryResult<number | null, Error> => {
+  let status: "loading" | "authenticated" | "unauthenticated";
+
+  if (!auth) {
+    const session = useSession();
+    status = session.status;
+  } else {
+    status = auth.status;
+  }
+
+  return useQuery({
+    queryKey: ["readingProgress", linkId],
+    queryFn: async () => {
+      const response = await fetch(
+        (auth?.instance ? auth.instance : "") +
+          `/api/v1/links/${linkId}/progress`,
+        auth?.session
+          ? {
+              headers: {
+                Authorization: `Bearer ${auth.session}`,
+              },
+            }
+          : undefined
+      );
+      if (!response.ok) throw new Error("Failed to fetch reading progress.");
+
+      const data = await response.json();
+      return (data.response as number | null) ?? null;
+    },
+    enabled: status === "authenticated" && !!linkId && enabled,
+  });
+};
+
+const useUpdateReadingProgress = (linkId?: number, auth?: MobileAuth) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (progress: number) => {
+      const response = await fetch(
+        (auth?.instance ? auth.instance : "") +
+          `/api/v1/links/${linkId}/progress`,
+        {
+          body: JSON.stringify({ progress }),
+          headers: {
+            "Content-Type": "application/json",
+            ...(auth?.session
+              ? { Authorization: `Bearer ${auth.session}` }
+              : {}),
+          },
+          method: "PUT",
+        }
+      );
+
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.response);
+
+      return progress;
+    },
+    onSuccess: (progress: number) => {
+      queryClient.setQueryData(["readingProgress", linkId], progress);
+    },
+  });
+};
+
+export { useGetReadingProgress, useUpdateReadingProgress };


### PR DESCRIPTION
## What does this PR do?

Hey, i tried out linkwarden and i have been missing the feature to resume my position in an article when wanting to continue to read it.

Resumes the reading position in the readable view. While reading, the scroll position is saved per user per link. It is enabled by default, since i assumed most users would want this feature, but users can turn it off in settings in the web.

- Fixes #1571

## Visual Demo 

A visual demonstration with "Save reading progress" and "Open Readable, if available" enabled.

#### Image Demo (if applicable):

1. Open in Browser:

<img width="821" height="728" alt="Screenshot_20260728_161846" src="https://github.com/user-attachments/assets/cce4d699-3c26-46a2-8191-ea9e22645b51" />

2. Open Article:

<img width="1649" height="991" alt="Screenshot_20260728_161913" src="https://github.com/user-attachments/assets/ac03d18d-f07d-47ed-bfec-71bdef2fb39a" />

3. Scroll to position:

<img width="1641" height="1238" alt="Screenshot_20260728_161941" src="https://github.com/user-attachments/assets/1cb80a02-fcbf-4293-b553-31a19bd0c351" />

4. Open App:

<img width="514" height="1139" alt="Screenshot_20260728_162029" src="https://github.com/user-attachments/assets/579df1d0-8b37-4ad9-af69-9584f95c1a9a" />

5. Open Article:

<img width="515" height="1153" alt="Screenshot_20260728_164945" src="https://github.com/user-attachments/assets/6322841b-7a1a-428f-9181-899f3d6f2600" />

## AI Assistance (Required)

We allow AI-assisted development, but reviewers need transparency to assess risk, maintainability, and correctness.

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code Fable

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification) (Except: Before merging ios still needs to be tested, since i don't have access to apple devices)
- [x] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected
