### PR TITLE
fix(docker): restore full Chromium for previews

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,12 +74,12 @@ COPY --from=app-builder /data/packages ./packages
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack install
 
-# Install only the Chromium headless shell (Playwright's smallest browser) plus
-# the shared libraries it needs at runtime. Full Chromium is not required.
+# Install full Chromium for compatibility with sites that reject the
+# headless-shell-only browser used by Playwright.
 RUN set -eux && \
     export PATH=/data/node_modules/.bin:$PATH && \
     apt-get update && \
-    playwright install --with-deps chromium-headless-shell && \
+    playwright install --with-deps chromium && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What does this PR do?

Restores the full Playwright Chromium browser in the production Docker image instead of installing `chromium-headless-shell`.

The reported regression began after the production image switched to the headless-shell-only browser. Facebook and Instagram return generic error pages when loaded using that browser target, causing incorrect bookmark previews.

This change keeps the current multi-stage Docker image while restoring the full Chromium browser previously used by Linkwarden.

- Fixes #1773

## Visual Demo

Not included because this change affects browser behavior inside the production container rather than the application UI.

## AI Assistance (Required)

#### AI usage level

- [ ] None
- [ ] Light
- [x] Medium
- [ ] Heavy

#### Which tools were used?

- OpenAI Codex was used to investigate the regression and prepare the Dockerfile change.

## What was verified by the author?

- [x] The patch changes only the production Playwright browser target
- [x] Dockerfile browser-target validation passed
- [x] `git diff --check` passed
- [ ] End-to-end Facebook and Instagram preview generation was not run locally

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected