### PR TITLE
feat(auth): optional zero-click SSO redirect

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,12 @@ AUTOSCROLL_TIMEOUT=
 NEXT_PUBLIC_DISABLE_REGISTRATION=
 NEXT_PUBLIC_CREDENTIALS_ENABLED=
 DISABLE_NEW_SSO_USERS=
+# Redirect straight to SSO instead of showing the login form.
+# SSO_AUTO_LOGIN_PROVIDER is only needed when more than one SSO provider is
+# configured (e.g. "authentik", "oidc", "keycloak").
+# Reach the login form at any time with /login?nosso=1
+NEXT_PUBLIC_SSO_AUTO_LOGIN=
+SSO_AUTO_LOGIN_PROVIDER=
 MAX_LINKS_PER_USER=
 ARCHIVE_TAKE_COUNT=
 BROWSER_TIMEOUT=

--- a/apps/web/components/ModalContent/DeleteOwnAccountModal.tsx
+++ b/apps/web/components/ModalContent/DeleteOwnAccountModal.tsx
@@ -52,7 +52,7 @@ export default function DeleteOwnAccountModal({ onClose }: Props) {
     toast.dismiss(load);
 
     if (response.ok) {
-      signOut();
+      signOut({ callbackUrl: "/login?nosso=1" });
     } else {
       toast.error(message);
       setSubmitLoader(false);

--- a/apps/web/components/ProfileDropdown.tsx
+++ b/apps/web/components/ProfileDropdown.tsx
@@ -193,7 +193,7 @@ export default function ProfileDropdown({
         </DropdownMenuSub>
 
         <DropdownMenuItem asChild>
-          <div onClick={() => signOut()} className="whitespace-nowrap">
+          <div onClick={() => signOut({ callbackUrl: "/login?nosso=1" })} className="whitespace-nowrap">
             <i className="bi-box-arrow-left" />
             {t("logout")}
           </div>

--- a/apps/web/pages/api/v1/logins/index.ts
+++ b/apps/web/pages/api/v1/logins/index.ts
@@ -14,6 +14,7 @@ export type ResponseData = {
     method: string;
     name: string;
   }[];
+  autoLoginProvider: string | null;
 };
 export default function handler(
   req: NextApiRequest,
@@ -30,6 +31,21 @@ export function getLogins() {
       name: getAuthProviderButtonName(entry),
     }));
 
+  // Only redirect automatically when the provider is unambiguous, otherwise
+  // fall back to the normal login page.
+  let autoLoginProvider: string | null = null;
+
+  if (process.env.NEXT_PUBLIC_SSO_AUTO_LOGIN === "true") {
+    const requested = process.env.SSO_AUTO_LOGIN_PROVIDER;
+
+    if (requested) {
+      autoLoginProvider =
+        buttonAuths.find((auth) => auth.method === requested)?.method ?? null;
+    } else if (buttonAuths.length === 1) {
+      autoLoginProvider = buttonAuths[0].method;
+    }
+  }
+
   return {
     credentialsEnabled:
       process.env.NEXT_PUBLIC_CREDENTIALS_ENABLED !== "false"
@@ -42,5 +58,6 @@ export function getLogins() {
         ? "true"
         : "false",
     buttonAuths: buttonAuths,
+    autoLoginProvider,
   };
 }

--- a/apps/web/pages/auth/verify-email.tsx
+++ b/apps/web/pages/auth/verify-email.tsx
@@ -24,7 +24,7 @@ const VerifyEmail = () => {
       if (res.ok) {
         toast.success(t("email_verified_signing_out"));
         setTimeout(() => {
-          signOut();
+          signOut({ callbackUrl: "/login?nosso=1" });
         }, 3000);
       } else {
         toast.error(t("invalid_token"));

--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -3,7 +3,7 @@ import TextInput from "@/components/TextInput";
 import CenteredForm from "@/components/CenteredForm";
 import { signIn } from "next-auth/react";
 import Link from "next/link";
-import React, { useState, FormEvent } from "react";
+import React, { useState, useEffect, FormEvent } from "react";
 import { toast } from "react-hot-toast";
 import { getLogins } from "./api/v1/logins";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
@@ -20,14 +20,29 @@ interface FormData {
   password: string;
 }
 
+// Set before an automatic SSO redirect and cleared on the next render of this
+// page. If it is still set we came back without a session, so the attempt
+// failed and we show the form instead of redirecting again.
+const SSO_ATTEMPT_COOKIE = "linkwarden_sso_auto_attempt";
+const SSO_BYPASS_PARAM = "nosso";
+
 export default function Login({
   availableLogins,
+  autoLoginProvider,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { t } = useTranslation();
 
   const router = useRouter();
 
   const [submitLoader, setSubmitLoader] = useState(false);
+
+  useEffect(() => {
+    if (!autoLoginProvider) return;
+
+    signIn(autoLoginProvider, {
+      callbackUrl: (router.query.callbackUrl as string) || "/dashboard",
+    });
+  }, [autoLoginProvider, router.query.callbackUrl]);
 
   const [form, setForm] = useState<FormData>({
     username: "",
@@ -257,6 +272,22 @@ export default function Login({
     }
   }
 
+  if (autoLoginProvider) {
+    return (
+      <CenteredForm header={t("sign_in_to_linkwarden")}>
+        <div className="mx-auto flex flex-col gap-3 justify-center items-center max-w-md min-w-80 w-full">
+          <p className="text-center">{t("authenticating")}</p>
+          <Link
+            href={`/login?${SSO_BYPASS_PARAM}=1`}
+            className="text-sm text-gray-500 dark:text-gray-400 underline"
+          >
+            {t("sign_in_another_way")}
+          </Link>
+        </div>
+      </CenteredForm>
+    );
+  }
+
   return (
     <CenteredForm header={t("sign_in_to_linkwarden")}>
       <form onSubmit={loginUser}>
@@ -276,6 +307,28 @@ export default function Login({
 const getServerSideProps: GetServerSideProps = async (ctx) => {
   const availableLogins = getLogins();
 
+  // Skip the automatic redirect on ?nosso=1, after a failed sign-in, or if the
+  // previous attempt already bounced back here, so a broken provider falls
+  // back to the login form rather than looping.
+  const ssoAttempted = ctx.req.cookies?.[SSO_ATTEMPT_COOKIE] === "1";
+  const ssoBypassed =
+    ctx.query[SSO_BYPASS_PARAM] !== undefined || ctx.query.error !== undefined;
+
+  let autoLoginProvider: string | null =
+    !ssoAttempted && !ssoBypassed ? availableLogins.autoLoginProvider : null;
+
+  if (autoLoginProvider) {
+    ctx.res.setHeader(
+      "Set-Cookie",
+      `${SSO_ATTEMPT_COOKIE}=1; Path=/; Max-Age=120; SameSite=Lax; HttpOnly`
+    );
+  } else if (ssoAttempted) {
+    ctx.res.setHeader(
+      "Set-Cookie",
+      `${SSO_ATTEMPT_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly`
+    );
+  }
+
   const acceptLanguageHeader = ctx.req.headers["accept-language"];
   const availableLanguages = i18n.locales;
 
@@ -292,6 +345,7 @@ const getServerSideProps: GetServerSideProps = async (ctx) => {
       return {
         props: {
           availableLogins,
+          autoLoginProvider: null,
           ...(await serverSideTranslations(user.locale ?? "en", ["common"])),
         },
       };
@@ -322,6 +376,7 @@ const getServerSideProps: GetServerSideProps = async (ctx) => {
   return {
     props: {
       availableLogins,
+      autoLoginProvider,
       ...(await serverSideTranslations(bestMatch ?? "en", ["common"])),
     },
   };

--- a/apps/web/pages/subscribe.tsx
+++ b/apps/web/pages/subscribe.tsx
@@ -187,7 +187,7 @@ export default function Subscribe() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="center">
-                <DropdownMenuItem onClick={() => signOut()}>
+                <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login?nosso=1" })}>
                   <i className="bi-box-arrow-right" />
                   {t("sign_out")}
                 </DropdownMenuItem>

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -561,6 +561,7 @@
   "search_unindexed_links_in_bg_info": "Search may be less accurate because some links are still being processed.",
   "reimagine_how_you_save_links": "Reimagine how you save links",
   "sign_in_to_linkwarden": "Welcome back!",
+  "sign_in_another_way": "Sign in another way",
   "or": "Or",
   "continue_with_apple": "Continue with Apple",
   "continue_with_google": "Continue with Google"


### PR DESCRIPTION
## What does this PR do?

Adds an option to send people straight to SSO instead of showing the login form first, so a single-provider setup does not need an extra click.

- Fixes #887

`NEXT_PUBLIC_SSO_AUTO_LOGIN=true` turns it on. `SSO_AUTO_LOGIN_PROVIDER` picks the provider when more than one is configured; with a single provider it resolves on its own, and if it cannot be resolved unambiguously the feature stays off rather than guessing.

The redirect is decided in `getServerSideProps` so the form never flashes before redirecting.

Getting back to the form matters more than the redirect, since a provider that is down should not lock people out. It is skipped when:

1. `?nosso=1` is present, an escape hatch that is also linked from the redirect screen
2. `?error=...` is present, meaning NextAuth returned here after a failed sign-in, so the error shows
3. a short-lived HttpOnly cookie set just before redirecting is still there, meaning the last attempt came back without a session. It is cleared on that render so a later visit can try again.

Sign-out now goes to `/login?nosso=1`, otherwise signing out immediately signs you back in.

## Visual Demo

To follow.

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

Claude (Anthropic).

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

Running on my own instance against Authentik. I verified all four paths by reading `autoLoginProvider` out of `__NEXT_DATA__`: `/login` has the provider set, while `?nosso=1`, `?error=...` and the attempt-cookie case are all null, with the cookie cleared on the fallback render.

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected