### PR TITLE
fix(web): keep avatar and locale on partial user updates

### DIFF
--- a/apps/web/lib/api/controllers/users/userId/updateUserById.test.ts
+++ b/apps/web/lib/api/controllers/users/userId/updateUserById.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "@linkwarden/prisma";
+import { removeFile } from "@linkwarden/filesystem";
+import updateUserById from "./updateUserById";
+
+vi.mock("@linkwarden/prisma", () => ({
+  prisma: {
+    user: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@linkwarden/filesystem", () => ({
+  createFile: vi.fn(),
+  createFolder: vi.fn(),
+  removeFile: vi.fn(),
+}));
+
+vi.mock("@/lib/api/sendChangeEmailVerificationRequest", () => ({
+  default: vi.fn(),
+}));
+
+const existingUser = {
+  id: 1,
+  name: "Olli",
+  username: "olli",
+  email: "olli@example.com",
+  password: "$2b$10$notarealhash",
+  image: "uploads/avatar/1.jpg",
+  locale: "de",
+  parentSubscriptionId: null,
+  referredBy: null,
+  accounts: [],
+};
+
+const updatePayload = () =>
+  (vi.mocked(prisma.user.update).mock.calls[0][0] as any).data;
+
+describe("updateUserById", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(existingUser as any);
+    vi.mocked(prisma.user.update).mockImplementation((async ({ data }: any) => {
+      const written = Object.fromEntries(
+        Object.entries(data).filter(([, value]) => value !== undefined)
+      );
+
+      return { ...existingUser, ...written };
+    }) as any);
+  });
+
+  it("keeps the avatar and locale when the request doesn't carry them", async () => {
+    const { response, status } = (await updateUserById(1, {
+      username: "olli",
+      email: "olli@example.com",
+      archiveAsScreenshot: true,
+    } as any)) as any;
+
+    expect(status).toBe(200);
+    expect(updatePayload().archiveAsScreenshot).toBe(true);
+    expect(updatePayload().image).toBeUndefined();
+    expect(updatePayload().locale).toBeUndefined();
+    expect(removeFile).not.toHaveBeenCalled();
+    expect(response.image).toMatch(/^uploads\/avatar\/1\.jpg\?/);
+    expect(response.locale).toBe("de");
+  });
+
+  it("removes the avatar when an empty image is sent", async () => {
+    const { status } = (await updateUserById(1, {
+      username: "olli",
+      email: "olli@example.com",
+      image: "",
+    } as any)) as any;
+
+    expect(status).toBe(200);
+    expect(updatePayload().image).toBe("");
+    expect(removeFile).toHaveBeenCalledWith({
+      filePath: "uploads/avatar/1.jpg",
+    });
+  });
+
+  it("falls back to en when an unsupported locale is sent", async () => {
+    const { status } = (await updateUserById(1, {
+      username: "olli",
+      email: "olli@example.com",
+      locale: "xx",
+    } as any)) as any;
+
+    expect(status).toBe(200);
+    expect(updatePayload().locale).toBe("en");
+  });
+});

--- a/apps/web/lib/api/controllers/users/userId/updateUserById.ts
+++ b/apps/web/lib/api/controllers/users/userId/updateUserById.ts
@@ -196,6 +196,25 @@ export default async function updateUserById(
     saltRounds
   );
 
+  // Partial updates shouldn't wipe the avatar or reset the locale, so these
+  // are only sent to the database when the request actually carries them.
+
+  const image =
+    data.image === undefined || data.image === null
+      ? undefined
+      : data.image.startsWith("http")
+        ? data.image
+        : data.image
+          ? `uploads/avatar/${userId}.jpg`
+          : "";
+
+  const locale =
+    data.locale === undefined
+      ? undefined
+      : i18n.locales.includes(data.locale)
+        ? data.locale
+        : "en";
+
   const updatedUser = await prisma.user.update({
     where: {
       id: userId,
@@ -203,19 +222,14 @@ export default async function updateUserById(
     data: {
       name: data.name,
       username: data.username,
-      image:
-        data.image && data.image.startsWith("http")
-          ? data.image
-          : data.image
-            ? `uploads/avatar/${userId}.jpg`
-            : "",
+      image,
       collectionOrder: data.collectionOrder?.filter(
         (value, index, self) => self.indexOf(value) === index
       ),
       aiTaggingMethod: data.aiTaggingMethod,
       aiPredefinedTags: data.aiPredefinedTags,
       aiTagExistingLinks: data.aiTagExistingLinks,
-      locale: i18n.locales.includes(data.locale || "") ? data.locale : "en",
+      locale,
       archiveAsScreenshot: data.archiveAsScreenshot,
       archiveAsMonolith: data.archiveAsMonolith,
       archiveAsPDF: data.archiveAsPDF,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,11 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(process.cwd(), "apps/web"),
+      // Next resolves this through the web app's tsconfig baseUrl, Vite doesn't.
+      "next-i18next.config": path.resolve(
+        process.cwd(),
+        "apps/web/next-i18next.config.js"
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## What does this PR do?

- Fixes #1779

The preferences page saves each section on its own, so the archive section sends a PUT with just the id, username, email and the five archive flags. `updateUserById` wrote `image` and `locale` on every call though. A missing `image` fell through to `""` and a missing `locale` fell through to `"en"`, so the response came back with a blank avatar and the wrong language, and the client cache picked those up until the next full page reload.

Both values are now worked out before the Prisma call and stay `undefined` when the request does not carry them, which tells Prisma to leave those columns alone. Everything that worked before still works: sending `image: ""` clears the avatar and still calls `removeFile`, a base64 upload still points at `uploads/avatar/<id>.jpg`, an http URL is kept as is, and an unknown locale still falls back to `"en"`. An explicit `null` image is now treated as no change too, it never removed the avatar file anyway because that branch only matches `""`.

I added `apps/web/lib/api/controllers/users/userId/updateUserById.test.ts` with three cases for the above. It fails on main and passes with the change. `vitest.config.mts` needed one extra alias because this controller imports `next-i18next.config`, which Next resolves through the web app's tsconfig baseUrl and Vite does not.

## Visual Demo

Nothing to show in a screenshot, the change is in the PUT response body. The steps from the issue reproduce it: set your language to something other than English, upload an avatar, then toggle an archive format and save. Before the change `PUT /api/v1/users/:id` answers with `"locale": "en"` and `"image": ""`, after it the stored values come back.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## AI Assistance (Required)

We allow AI-assisted development, but reviewers need transparency to assess risk, maintainability, and correctness.

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

I ran `yarn vitest run` locally. The new file passes and the rest of the suite is unchanged, the only failure is `importFromHTMLFile.test.ts`, which needs a `DATABASE_URL` and fails the same way without this change. `tsc --noEmit` on the web app is clean.

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected