### PR TITLE
fix(worker): keep aiTagged false when AI tagging fails

### DIFF
--- a/apps/worker/lib/autoTagLink.test.ts
+++ b/apps/worker/lib/autoTagLink.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateText } from "ai";
+import { prisma } from "@linkwarden/prisma";
+import autoTagLink from "./autoTagLink";
+
+vi.mock("ai", () => ({
+  generateText: vi.fn(),
+}));
+
+vi.mock("@linkwarden/prisma", () => ({
+  prisma: {
+    link: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    tag: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const user = {
+  id: 1,
+  aiTaggingMethod: "GENERATE",
+  aiPredefinedTags: [],
+} as any;
+
+describe("autoTagLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    vi.stubEnv("OPENAI_MODEL", "test-model");
+
+    vi.mocked(prisma.link.findUnique).mockResolvedValue({
+      id: 1,
+      url: "https://example.com",
+      metaDescription: "A page about Python and machine learning.",
+      textContent: null,
+    } as any);
+    vi.mocked(prisma.link.update).mockResolvedValue({} as any);
+  });
+
+  it("tags the link when the AI returns a usable array", async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      text: '["Python", "Machine Learning"]',
+    } as any);
+
+    await expect(autoTagLink(user, 1)).resolves.toBe("tagged");
+
+    expect(prisma.link.update).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(prisma.link.update).mock.calls[0][0].data.aiTagged).toBe(
+      true
+    );
+  });
+
+  it("throws and leaves the link untagged when the AI yaps instead of answering", async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      text: "I'm sorry, I can't help with that request.",
+    } as any);
+
+    await expect(autoTagLink(user, 1)).rejects.toThrow();
+
+    expect(prisma.link.update).not.toHaveBeenCalled();
+  });
+
+  it("throws and leaves the link untagged when the AI returns broken JSON", async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      text: '```json\n["Python", ',
+    } as any);
+
+    await expect(autoTagLink(user, 1)).rejects.toThrow();
+
+    expect(prisma.link.update).not.toHaveBeenCalled();
+  });
+
+  it("throws and leaves the link untagged when the provider errors", async () => {
+    vi.mocked(generateText).mockRejectedValue(
+      new Error("429 Too Many Requests")
+    );
+
+    await expect(autoTagLink(user, 1)).rejects.toThrow("429 Too Many Requests");
+
+    expect(prisma.link.update).not.toHaveBeenCalled();
+  });
+
+  it("skips the link when there is nothing to describe it", async () => {
+    vi.mocked(prisma.link.findUnique).mockResolvedValue({
+      id: 1,
+      url: "https://example.com",
+      metaDescription: null,
+      textContent: null,
+    } as any);
+
+    await expect(autoTagLink(user, 1)).resolves.toBe("skipped");
+
+    expect(generateText).not.toHaveBeenCalled();
+    expect(prisma.link.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/lib/autoTagLink.ts
+++ b/apps/worker/lib/autoTagLink.ts
@@ -17,6 +17,12 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createOllama } from "ollama-ai-provider-v2";
 import { titleCase } from "@linkwarden/lib/utils";
+import parseAiTagResponse from "./parseAiTagResponse";
+
+// "skipped" means there is nothing to tag and retrying won't help. A genuine
+// failure (provider error, unusable response) throws so the caller can leave
+// the link untagged and try again later.
+export type AutoTagResult = "tagged" | "skipped";
 
 // Function to concat /api with the base URL properly
 const ensureValidURL = (base: string, path: string) =>
@@ -66,18 +72,24 @@ const getAIModel = (): LanguageModelV2 => {
   throw new Error("No AI provider configured");
 };
 
-export default async function autoTagLink(user: User, linkId: number) {
+export default async function autoTagLink(
+  user: User,
+  linkId: number
+): Promise<AutoTagResult> {
   const link = await prisma.link.findUnique({
     where: { id: linkId },
   });
 
-  if (!link) return console.log("Link not found for auto tagging.");
+  if (!link) {
+    console.log("Link not found for auto tagging.");
+    return "skipped";
+  }
 
   const description =
     (link.metaDescription ? link.metaDescription + "..." : undefined) ||
     (link.textContent ? link.textContent?.slice(0, 500) + "..." : undefined);
 
-  if (!description) return;
+  if (!description) return "skipped";
 
   let prompt;
 
@@ -119,7 +131,8 @@ export default async function autoTagLink(user: User, linkId: number) {
     user.aiTaggingMethod === AiTaggingMethod.PREDEFINED &&
     user.aiPredefinedTags.length === 0
   ) {
-    return console.log("No predefined tags to auto tag for link: ", link.url);
+    console.log("No predefined tags to auto tag for link: ", link.url);
+    return "skipped";
   }
 
   const { text } = await generateText({
@@ -127,57 +140,60 @@ export default async function autoTagLink(user: User, linkId: number) {
     prompt: prompt,
   });
 
-  try {
-    // If text has an array inside a "```json ```" block, extract that
-    let tags: string[] = JSON.parse(
-      text.match(/```json\s*([\s\S]*?)\s*```/i)?.[1] ?? text
+  let tags = parseAiTagResponse(text);
+
+  if (!tags) {
+    throw new Error(
+      `The AI response for ${link.url} didn't contain a list of tags: ${text.slice(
+        0,
+        200
+      )}`
     );
-
-    if (!tags || tags.length === 0) {
-      return;
-    } else if (user.aiTaggingMethod === AiTaggingMethod.EXISTING) {
-      tags = tags.filter((tag: string) => existingTagsNames.includes(tag));
-    } else if (user.aiTaggingMethod === AiTaggingMethod.PREDEFINED) {
-      tags = tags.filter((tag: string) => user.aiPredefinedTags.includes(tag));
-    } else if (user.aiTaggingMethod === AiTaggingMethod.GENERATE) {
-      tags = tags.map((tag: string) =>
-        tag.length > 3 ? titleCase(tag.toLowerCase()) : tag
-      );
-    }
-
-    console.log("Tags for link:", link.url, "=>", tags);
-
-    if (tags.length > 5) {
-      tags = tags.slice(0, 5);
-    }
-
-    await prisma.link.update({
-      where: { id: linkId },
-      data: {
-        tags: {
-          connectOrCreate: tags.map((tag: string) => ({
-            where: {
-              name_ownerId: {
-                name: tag.trim().slice(0, 50),
-                ownerId: user.id,
-              },
-            },
-            create: {
-              name: tag.trim().slice(0, 50),
-              owner: {
-                connect: {
-                  id: user.id,
-                },
-              },
-              aiGenerated: true,
-            },
-          })),
-        },
-        aiTagged: true,
-      },
-    });
-  } catch (err) {
-    console.log("Error auto tagging link: ", link.url);
-    console.log("Error: ", err);
   }
+
+  if (tags.length === 0) return "skipped";
+
+  if (user.aiTaggingMethod === AiTaggingMethod.EXISTING) {
+    tags = tags.filter((tag: string) => existingTagsNames.includes(tag));
+  } else if (user.aiTaggingMethod === AiTaggingMethod.PREDEFINED) {
+    tags = tags.filter((tag: string) => user.aiPredefinedTags.includes(tag));
+  } else if (user.aiTaggingMethod === AiTaggingMethod.GENERATE) {
+    tags = tags.map((tag: string) =>
+      tag.length > 3 ? titleCase(tag.toLowerCase()) : tag
+    );
+  }
+
+  console.log("Tags for link:", link.url, "=>", tags);
+
+  if (tags.length > 5) {
+    tags = tags.slice(0, 5);
+  }
+
+  await prisma.link.update({
+    where: { id: linkId },
+    data: {
+      tags: {
+        connectOrCreate: tags.map((tag: string) => ({
+          where: {
+            name_ownerId: {
+              name: tag.trim().slice(0, 50),
+              ownerId: user.id,
+            },
+          },
+          create: {
+            name: tag.trim().slice(0, 50),
+            owner: {
+              connect: {
+                id: user.id,
+              },
+            },
+            aiGenerated: true,
+          },
+        })),
+      },
+      aiTagged: true,
+    },
+  });
+
+  return "tagged";
 }

--- a/apps/worker/lib/parseAiTagResponse.test.ts
+++ b/apps/worker/lib/parseAiTagResponse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import parseAiTagResponse from "./parseAiTagResponse";
+
+describe("parseAiTagResponse", () => {
+  it("parses a bare JSON array", () => {
+    expect(parseAiTagResponse('["Machine Learning", "Python"]')).toEqual([
+      "Machine Learning",
+      "Python",
+    ]);
+  });
+
+  it("parses an array inside a fenced code block", () => {
+    expect(
+      parseAiTagResponse('```json\n["Web Development", "CSS"]\n```')
+    ).toEqual(["Web Development", "CSS"]);
+  });
+
+  it("parses an array wrapped in prose", () => {
+    expect(
+      parseAiTagResponse(
+        'Sure! Here are the tags for this page: ["API", "AWS"]. Let me know if you want more.'
+      )
+    ).toEqual(["API", "AWS"]);
+  });
+
+  it("drops entries that aren't usable tags", () => {
+    expect(parseAiTagResponse('["Python", 42, "  ", null, " AI "]')).toEqual([
+      "Python",
+      "AI",
+    ]);
+  });
+
+  it("returns an empty array when the model found no tags", () => {
+    expect(parseAiTagResponse("[]")).toEqual([]);
+  });
+
+  it("parses an array the model nested in an object", () => {
+    expect(parseAiTagResponse('{"tags": ["Python"]}')).toEqual(["Python"]);
+  });
+
+  it("returns null when the response has no array", () => {
+    expect(parseAiTagResponse("")).toBeNull();
+    expect(parseAiTagResponse("I couldn't find any relevant tags.")).toBeNull();
+  });
+
+  it("returns null when the array is broken", () => {
+    expect(parseAiTagResponse('["Python", "AI"')).toBeNull();
+    expect(parseAiTagResponse("```json\n[Python, AI]\n```")).toBeNull();
+  });
+});

--- a/apps/worker/lib/parseAiTagResponse.ts
+++ b/apps/worker/lib/parseAiTagResponse.ts
@@ -1,0 +1,36 @@
+/**
+ * Extracts the tag array out of an AI response.
+ *
+ * Models don't always follow the "output ONLY a JSON array" instruction, so on
+ * top of a bare array we also accept a fenced code block and an array wrapped
+ * in prose. Returns null when the response holds no usable array, so the caller
+ * can treat it as a failure instead of silently dropping the link.
+ */
+export default function parseAiTagResponse(text: string): string[] | null {
+  if (!text) return null;
+
+  const candidates = [
+    text.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)?.[1],
+    text,
+    text.match(/\[[\s\S]*\]/)?.[0],
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const candidate of candidates) {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+
+    if (!Array.isArray(parsed)) continue;
+
+    return parsed
+      .filter((tag): tag is string => typeof tag === "string")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  }
+
+  return null;
+}

--- a/apps/worker/workers/autoTagPreservedLinks.ts
+++ b/apps/worker/workers/autoTagPreservedLinks.ts
@@ -6,6 +6,26 @@ import getLinkBatchFairly from "../lib/getLinkBatchFairly";
 
 const AUTO_TAG_TAKE_COUNT = Number(process.env.ARCHIVE_TAKE_COUNT || "") || 5;
 
+// A link that keeps failing would otherwise be picked again on every round and
+// starve the batch, so we give up on it after this many tries.
+const MAX_AUTO_TAG_ATTEMPTS = 3;
+
+const failedAttempts = new Map<number, number>();
+
+const markAsTagged = (linkId: number) =>
+  prisma.link
+    .update({
+      where: { id: linkId },
+      data: { aiTagged: true },
+    })
+    .catch((error) => {
+      console.error(
+        "\x1b[34m%s\x1b[0m",
+        `Error marking link ${linkId} as auto-tagged:`,
+        error
+      );
+    });
+
 const hasAiTaggingProvider = () =>
   Boolean(
     process.env.NEXT_PUBLIC_OLLAMA_ENDPOINT_URL ||
@@ -40,31 +60,38 @@ export async function autoTagPreservedLinks(interval = 10) {
             `Auto-tagging link ${link.url} for user ${link.collection.ownerId}.`
           );
 
-          await autoTagLink(link.collection.owner, link.id);
+          const result = await autoTagLink(link.collection.owner, link.id);
+
+          // Nothing to tag, so mark it as done to keep it out of the next batch.
+          if (result === "skipped") await markAsTagged(link.id);
+
+          failedAttempts.delete(link.id);
 
           console.log(
             "\x1b[34m%s\x1b[0m",
-            `Succeeded auto-tagging link ${link.url} for user ${link.collection.ownerId}.`
+            `${
+              result === "skipped" ? "Skipped" : "Succeeded"
+            } auto-tagging link ${link.url} for user ${link.collection.ownerId}.`
           );
         } catch (error: any) {
+          const attempts = (failedAttempts.get(link.id) ?? 0) + 1;
+          failedAttempts.set(link.id, attempts);
+
           console.error(
             "\x1b[34m%s\x1b[0m",
-            `Error auto-tagging link ${link.url} for user ${link.collection.ownerId}:`,
+            `Error auto-tagging link ${link.url} for user ${link.collection.ownerId} (attempt ${attempts} of ${MAX_AUTO_TAG_ATTEMPTS}):`,
             error
           );
-        } finally {
-          await prisma.link
-            .update({
-              where: { id: link.id },
-              data: { aiTagged: true },
-            })
-            .catch((error) => {
-              console.error(
-                "\x1b[34m%s\x1b[0m",
-                `Error marking link ${link.id} as auto-tagged:`,
-                error
-              );
-            });
+
+          if (attempts >= MAX_AUTO_TAG_ATTEMPTS) {
+            console.error(
+              "\x1b[34m%s\x1b[0m",
+              `Giving up on link ${link.id} after ${attempts} failed attempts, marking it as auto-tagged.`
+            );
+
+            failedAttempts.delete(link.id);
+            await markAsTagged(link.id);
+          }
         }
       }
     );


### PR DESCRIPTION
## What does this PR do?

The auto-tagging worker set `aiTagged: true` in a `finally` block, so the flag was written whether or not tagging worked. `autoTagLink` also caught its own JSON parse error and returned as if nothing had gone wrong. So when the model replied with prose, a truncated array, or the provider returned an error, the link ended up with no tags and `aiTagged` set to true, and it was never picked up again because the batch query only looks at links where `aiTagged` is false. That is what the log in the issue shows, an error printed right next to the link being marked as done.

`autoTagLink` now returns `"tagged"` or `"skipped"` and throws on a real failure. The response parsing moved into a small `parseAiTagResponse` helper that reads a bare array, an array in a fenced code block, or an array wrapped in prose, and returns null when there is nothing usable. The worker marks a link as tagged only when tagging worked or when there was nothing to tag, so a failed link stays in the queue and gets tried again on the next round.

To stop a permanently broken provider from picking the same failing links forever and filling the batch, the worker counts failures per link in memory and gives up after 3 tries, logging why before it marks the link as tagged.

- Fixes #1772

## Visual Demo

No UI change, this only affects the worker and what it writes to the database and the logs.

#### Video Demo (if applicable):

N/A

#### Image Demo (if applicable):

N/A

## AI Assistance (Required)

We allow AI-assisted development, but reviewers need transparency to assess risk, maintainability, and correctness.

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [x] Medium (AI suggested small code changes/snippets that I adapted)
- [ ] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code. It wrote the first pass of the code and the tests, and I read through all of it and adjusted it before pushing.

## What was verified by the author?

Added `apps/worker/lib/parseAiTagResponse.test.ts` and `apps/worker/lib/autoTagLink.test.ts`. Both are plain unit tests, the model call and Prisma are mocked, so they need no database and no provider key. `yarn vitest run apps/worker/lib` passes 13 tests and `yarn workspace @linkwarden/worker typecheck` is clean. The `autoTagLink` tests fail on the current code with "promise resolved undefined instead of rejecting", which is the swallowed error from the issue, and pass with this change.

I did not point this at a live LLM, so the retry counting in the worker loop is covered by reading rather than by a test.

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected