### PR TITLE
fix(migration): honour a fractional IMPORT_LIMIT

### DIFF
--- a/apps/web/pages/api/v1/migration/index.test.ts
+++ b/apps/web/pages/api/v1/migration/index.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getImportLimitMb } from "./index";
+
+describe("getImportLimitMb", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("keeps a fractional megabyte limit", () => {
+    vi.stubEnv("IMPORT_LIMIT", "0.002");
+
+    expect(getImportLimitMb()).toBe(0.002);
+  });
+
+  it("reads a whole megabyte limit", () => {
+    vi.stubEnv("IMPORT_LIMIT", "25");
+
+    expect(getImportLimitMb()).toBe(25);
+  });
+
+  it("defaults to 10 when unset", () => {
+    vi.stubEnv("IMPORT_LIMIT", "");
+
+    expect(getImportLimitMb()).toBe(10);
+  });
+
+  it("defaults to 10 when the value is not a number", () => {
+    vi.stubEnv("IMPORT_LIMIT", "ten");
+
+    expect(getImportLimitMb()).toBe(10);
+  });
+});

--- a/apps/web/pages/api/v1/migration/index.ts
+++ b/apps/web/pages/api/v1/migration/index.ts
@@ -14,6 +14,11 @@ export const config = {
   },
 };
 
+export const getImportLimitMb = (): number => {
+  const configured = Number.parseFloat(process.env.IMPORT_LIMIT ?? "");
+  return Number.isFinite(configured) ? configured : 10;
+};
+
 const parseJsonStream = (
   req: NextApiRequest,
   limitMb: number
@@ -67,18 +72,14 @@ export default async function users(req: NextApiRequest, res: NextApiResponse) {
 
     let request: MigrationRequest;
 
-    try {
-      const limitMb = process.env.IMPORT_LIMIT
-        ? parseInt(process.env.IMPORT_LIMIT, 10)
-        : 10;
+    const limitMb = getImportLimitMb();
 
+    try {
       request = await parseJsonStream(req, limitMb);
     } catch (error: any) {
       if (error.message === "Payload Too Large") {
         return res.status(413).json({
-          response: `Import file exceeds the ${
-            process.env.IMPORT_LIMIT || 10
-          }MB size limit.`,
+          response: `Import file exceeds the ${limitMb}MB size limit.`,
         });
       }
       return res


### PR DESCRIPTION
## What does this PR do?

- Fixes #1811

`IMPORT_LIMIT` is documented in megabytes but read with `parseInt`, so any value below 1 truncates to `0`. `parseJsonStream` then computes a budget of `0 * 1024 * 1024` bytes and rejects every import with `413`, however small. The 413 body reads `process.env.IMPORT_LIMIT` rather than the parsed value, so the operator is told a limit that is not the one being enforced.

The limit is now parsed with `Number.parseFloat`, resolved once in `getImportLimitMb()`, and that value is what the error message reports. A non-numeric `IMPORT_LIMIT` previously produced `NaN`, and `totalLength > NaN` is always false, so a typo silently removed the cap entirely; it now falls back to the documented 10 MB default.

`getImportLimitMb` is exported so it can be unit-tested, following `getEnvData` in `pages/api/v1/config/index.ts`.

## Visual Demo

No UI change. The behaviour difference, for the same code path:

| `IMPORT_LIMIT` | before | after |
|---|---|---|
| `0.002` | `0` → 0 bytes, everything rejected | `0.002` → 2097 bytes |
| `0.5` | `0` → 0 bytes, everything rejected | `0.5` → 524288 bytes |
| `25` | `25` → 26214400 bytes | unchanged |
| unset | `10` → 10485760 bytes | unchanged |
| `ten` | `NaN` → no limit enforced | `10` → 10485760 bytes |

The issue's reproduction — a ~140 byte body under `IMPORT_LIMIT=0.002` — is over the old budget and under the new one.

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [x] Medium (AI suggested small code changes/snippets that I adapted)
- [ ] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude

## What was verified by the author?

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

New `apps/web/pages/api/v1/migration/index.test.ts` covers a fractional limit, a whole-number limit, an unset value and a non-numeric value: 4 passing. `yarn vitest run` otherwise passes 43 tests, with `importFromHTMLFile.test.ts` erroring before and after because it requires `DATABASE_URL`. Prettier is clean on both files.

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected