### PR TITLE
fix(web): prefer Open Graph article titles

### DIFF
--- a/apps/web/lib/shared/extractTitle.test.ts
+++ b/apps/web/lib/shared/extractTitle.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractTitle } from "./extractTitle";
+
+describe("extractTitle", () => {
+  it("prefers the article title from the Open Graph metadata", () => {
+    const html = `
+      <title>Golem</title>
+      <meta property="og:title" content="Shieldfont Diese Schrift füttert KI-Crawler mit Unsinn">
+    `;
+
+    expect(extractTitle(html)).toBe(
+      "Shieldfont Diese Schrift füttert KI-Crawler mit Unsinn",
+    );
+  });
+
+  it("supports Open Graph attributes in either order", () => {
+    expect(
+      extractTitle('<meta content="Article title" property="og:title">'),
+    ).toBe("Article title");
+  });
+
+  it("falls back to the document title when Open Graph metadata is absent", () => {
+    expect(extractTitle("<title>Fallback title</title>")).toBe("Fallback title");
+  });
+});

--- a/apps/web/lib/shared/extractTitle.ts
+++ b/apps/web/lib/shared/extractTitle.ts
@@ -1,0 +1,20 @@
+const extractMetaTitle = (html: string) => {
+  const metaTags = html.match(/<meta\b[^>]*>/gi) ?? [];
+
+  for (const tag of metaTags) {
+    const property = tag.match(/\bproperty\s*=\s*["']([^"']+)["']/i)?.[1];
+    if (property?.toLowerCase() !== "og:title") continue;
+
+    const content = tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i)?.[1];
+    if (content) return content.trim();
+  }
+
+  return "";
+};
+
+export const extractTitle = (html: string) => {
+  const metaTitle = extractMetaTitle(html);
+  if (metaTitle) return metaTitle;
+
+  return html.match(/<title\b[^>]*>([^<]*)<\/title>/i)?.[1]?.trim() ?? "";
+};

--- a/apps/web/lib/shared/fetchTitleAndHeaders.ts
+++ b/apps/web/lib/shared/fetchTitleAndHeaders.ts
@@ -1,4 +1,5 @@
 import { safeFetch } from "@linkwarden/lib/safeFetch";
+import { extractTitle } from "./extractTitle";
 
 export default async function fetchTitleAndHeaders(
   url: string,
@@ -28,10 +29,7 @@ export default async function fetchTitleAndHeaders(
 
       const headers = (response as Response | null)?.headers || null;
 
-      // regular expression to find the <title> tag
-      let match = text.match(/<title.*>([^<]*)<\/title>/);
-
-      const title = match?.[1] || "";
+      const title = extractTitle(text);
 
       return { title, headers };
     } else {


### PR DESCRIPTION
## Issue

Fixes #1791.

## Background

Some sites, including golem.de, use the site name in the HTML `<title>` while exposing the article title in `og:title`. Linkwarden therefore saved `Golem` instead of the article title.

## Changes

- Prefer the `og:title` metadata value when extracting a title.
- Fall back to the document `<title>` for pages without Open Graph metadata.
- Add regression coverage for Open Graph precedence, attribute order, and fallback behavior.

## Compatibility

Pages without `og:title` retain the existing document-title behavior. No public API or persisted data format changes are introduced.

## Tests

- `node --experimental-strip-types --input-type=module -e '...extractTitle assertions...'` — passed.

The repository Yarn dependency installation was attempted with `corepack yarn install --immutable` but did not complete after more than 10 minutes during the fetch step, so the Vitest suite, formatter, linter, and type checker were not run locally. The focused assertions use the same TypeScript helper and do not require external services or credentials.

## Known limitations

The parser intentionally only changes title-source precedence; HTML entity decoding and broader metadata normalization remain unchanged.
