### PR TITLE
fix(import): keep root folders separate from nested namesakes

### DIFF
--- a/apps/web/lib/api/controllers/migration/importFromHTMLFile.hierarchy.test.ts
+++ b/apps/web/lib/api/controllers/migration/importFromHTMLFile.hierarchy.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { prisma } from "@linkwarden/prisma";
+import importFromHTMLFile from "./importFromHTMLFile";
+
+vi.mock("@linkwarden/filesystem", () => ({ createFolder: vi.fn() }));
+vi.mock("@linkwarden/lib/verifyCapacity", () => ({
+  hasPassedLimit: vi.fn().mockResolvedValue(false),
+}));
+
+let userId: number;
+
+beforeAll(async () => {
+  const user = await prisma.user.create({
+    data: { username: `hierarchy_${Date.now()}` },
+  });
+  userId = user.id;
+});
+
+afterAll(async () => {
+  if (userId) await prisma.user.delete({ where: { id: userId } });
+  await prisma.$disconnect();
+});
+
+describe("HTML import folder identity", () => {
+  it("keeps a root folder separate from an earlier nested folder with the same name", async () => {
+    const html = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+      <DL><p>
+        <DT><H3>Parent</H3>
+        <DL><p>
+          <DT><H3>Shared</H3>
+          <DL><p><DT><A HREF="https://example.com/nested">Nested</A></DL><p>
+        </DL><p>
+        <DT><H3>Shared</H3>
+        <DL><p><DT><A HREF="https://example.com/root">Root</A></DL><p>
+      </DL><p>`;
+
+    await expect(importFromHTMLFile(userId, html)).resolves.toMatchObject({
+      status: 200,
+    });
+    const folders = await prisma.collection.findMany({
+      where: { ownerId: userId },
+    });
+    const parent = folders.find((folder) => folder.name === "Parent");
+    const root = folders.find(
+      (folder) => folder.name === "Shared" && folder.parentId === null
+    );
+    const nested = folders.find(
+      (folder) => folder.name === "Shared" && folder.parentId === parent?.id
+    );
+
+    expect(root).toBeDefined();
+    expect(nested).toBeDefined();
+    expect(root?.id).not.toBe(nested?.id);
+    const links = await prisma.link.findMany({
+      where: { createdById: userId },
+    });
+    expect(
+      links.find((link) => link.url === "https://example.com/root")
+        ?.collectionId
+    ).toBe(root?.id);
+    expect(
+      links.find((link) => link.url === "https://example.com/nested")
+        ?.collectionId
+    ).toBe(nested?.id);
+
+    await importFromHTMLFile(userId, html);
+    expect(await prisma.collection.count({ where: { ownerId: userId } })).toBe(
+      3
+    );
+  });
+
+  it("does not reuse a nested Imports folder for unfiled bookmarks", async () => {
+    const parent = await prisma.collection.create({
+      data: { name: "Another parent", ownerId: userId },
+    });
+    const nested = await prisma.collection.create({
+      data: { name: "Imports", ownerId: userId, parentId: parent.id },
+    });
+
+    await importFromHTMLFile(
+      userId,
+      '<DL><p><DT><A HREF="https://example.com/unfiled">Unfiled</A></DL><p>'
+    );
+    const link = await prisma.link.findFirst({
+      where: { url: "https://example.com/unfiled", createdById: userId },
+      include: { collection: true },
+    });
+    expect(link?.collection.name).toBe("Imports");
+    expect(link?.collection.parentId).toBeNull();
+    expect(link?.collectionId).not.toBe(nested.id);
+  });
+});

--- a/apps/web/lib/api/controllers/migration/importFromHTMLFile.ts
+++ b/apps/web/lib/api/controllers/migration/importFromHTMLFile.ts
@@ -159,7 +159,8 @@ const createCollection = async (
 
   const findCollection = await prisma.collection.findFirst({
     where: {
-      parentId,
+      // An omitted Prisma filter matches every parent, including nested folders.
+      parentId: parentId ?? null,
       name: collectionName,
       ownerId: userId,
     },


### PR DESCRIPTION
## What does this PR do?

Keep a top-level imported folder separate from an existing nested folder with the same name. Prisma omits an `undefined` `parentId` filter, so importing `Shared` at the root could reuse `Parent / Shared`. Use `parentId: null` for the root lookup. The same correction keeps unfiled bookmarks out of an unrelated nested `Imports` folder.

Addresses a reproducible root-folder collision from #1757. Nested parent IDs are already part of the lookup; this is a focused correction rather than an importer rewrite.

## Visual Demo

Database/import behavior:

| Input | Before | After |
| --- | --- | --- |
| `Parent / Shared` followed by root `Shared` | Both sets of bookmarks go into the nested folder | Distinct root and nested collections |
| An unfiled bookmark when `Parent / Imports` exists | Goes into the nested collection | Goes into root `Imports` |

## What was verified by the author?

- Two integration regressions passed on `bd6849573bab918347a3d58698c3744d8804c386`, based on current `dev` `caeccb3`. Both fail against the original importer. The first also verifies that repeating the import reuses the same three collections.
- Tests use the actual HTML parser, production Prisma schema/client, and a disposable PostgreSQL 16 database. Filesystem creation and capacity checks are mocked to isolate collection identity.
- Focused QA dependencies: Node 24.20.0, Vitest 4.1.0, Prisma 6.10.1, jsdom 22.1.0, himalaya 1.1.0, entities 4.5.0. This was a targeted dependency environment, not a complete Yarn workspace installation.
- Prettier and whitespace checks passed. Full application build, full test suite, and browser import flow were not run.

With the normal workspace installed and Prisma generated, initialize an empty disposable test database from `packages/prisma/schema.prisma`, then run:

```sh
DATABASE_URL=<disposable-test-database> yarn vitest run apps/web/lib/api/controllers/migration/importFromHTMLFile.hierarchy.test.ts
```

- [x] I reviewed **and** understood all AI/human generated code (Codex self-review)
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

## AI Assistance (Required)

- [ ] None
- [ ] Light
- [ ] Medium
- [x] Heavy

Tool: Codex implemented and tested this change under the submitter's authorization. No independent human review is claimed.

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected
