### PR TITLE
[Browser Extension] Add account-backed default collection setting

### DIFF
--- a/apps/extension/src/@/components/BookmarkForm.tsx
+++ b/apps/extension/src/@/components/BookmarkForm.tsx
@@ -23,7 +23,7 @@ import {
   setStorageItem,
   updateBadge,
 } from "../lib/utils.ts";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
 import { getConfig, isConfigured as getIsConfigured } from "../lib/config.ts";
 import { checkLinkExists, postLink } from "../lib/actions/links.ts";
@@ -53,6 +53,7 @@ const BookmarkForm = () => {
   const [config, setConfig] = useState<{
     baseUrl: string;
     defaultCollection: string;
+    defaultCollectionId?: number;
     apiKey: string;
     syncBookmarks: boolean;
   }>();
@@ -205,6 +206,33 @@ const BookmarkForm = () => {
     },
     enabled: isConfigured,
   });
+
+  // Once the collections are loaded, resolve the configured default to its full
+  // object (id/ownerId/name) so the link lands in exactly that collection — the
+  // API resolves by name otherwise, and names are not unique across the tree.
+  // This runs only once, so a later refetch never overrides a manual choice.
+  const defaultApplied = useRef(false);
+
+  useEffect(() => {
+    if (!collections || !config || defaultApplied.current) return;
+    defaultApplied.current = true;
+
+    // Prefer the stored id, but fall back to the name for configs saved before
+    // the id was stored (or if that collection has since been deleted).
+    const match =
+      (config.defaultCollectionId !== undefined
+        ? collections.find((c) => c.id === config.defaultCollectionId)
+        : undefined) ??
+      collections.find((c) => c.name === config.defaultCollection);
+
+    if (!match) return;
+
+    form.setValue("collection", {
+      id: match.id,
+      ownerId: match.ownerId,
+      name: match.name,
+    });
+  }, [collections, config, form]);
 
   const { data: shouldUseTagSearch = false } = useQuery({
     queryKey: ["tag-search-support", config?.baseUrl, config?.apiKey],

--- a/apps/extension/src/@/components/DefaultCollectionInput.tsx
+++ b/apps/extension/src/@/components/DefaultCollectionInput.tsx
@@ -1,0 +1,138 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Label } from "./ui/Label.tsx";
+import SelectInput, { SelectOption } from "./SelectInput.tsx";
+import { getCollections } from "../lib/actions/collections.ts";
+import { updateConfig } from "../lib/config.ts";
+import { toast } from "../../hooks/useToast.ts";
+
+// Sentinel for "no specific collection". Linkwarden creates the "Unorganized"
+// collection on demand, so it is not guaranteed to be in the list yet — this
+// keeps the option available (and resettable) either way.
+const UNORGANIZED = "unorganized";
+
+type Props = {
+  baseUrl: string;
+  apiKey: string;
+  /** The default collection currently stored in the config, if any. */
+  initialCollectionId?: number;
+};
+
+/**
+ * Lets a signed-in user pick the collection new links are pre-assigned to.
+ *
+ * The options come from the configured account, so only a collection that
+ * actually exists can be chosen. The choice is persisted as soon as it is
+ * made — the settings panel it lives in has no submit button of its own.
+ */
+const DefaultCollectionInput = ({
+  baseUrl,
+  apiKey,
+  initialCollectionId,
+}: Props) => {
+  const [selectedId, setSelectedId] = useState(initialCollectionId);
+
+  const {
+    data: collections,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["collections", baseUrl, apiKey],
+    queryFn: async () => {
+      const response = await getCollections(baseUrl, apiKey);
+
+      return response.data.response.sort((a, b) =>
+        a.pathname.localeCompare(b.pathname)
+      );
+    },
+  });
+
+  const options = useMemo<SelectOption[]>(
+    () => [
+      { value: UNORGANIZED, label: "Unorganized" },
+      // The pathname keeps nested collections with the same name apart.
+      ...(collections ?? []).map((collection) => ({
+        value: String(collection.id),
+        label: collection.pathname,
+      })),
+    ],
+    [collections]
+  );
+
+  const { mutate: onSelect } = useMutation({
+    mutationFn: async (value: string) => {
+      const collection =
+        value === UNORGANIZED
+          ? undefined
+          : collections?.find((c) => c.id === Number(value));
+
+      // A partial update rather than a full save: signing out while this is in
+      // flight must clear the account for good, not have it written back here.
+      const saved = await updateConfig({
+        defaultCollection: collection?.name ?? "Unorganized",
+        defaultCollectionId: collection?.id,
+      });
+
+      return { saved: saved !== null, collection };
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "Could not save the default collection. Please try again.",
+        variant: "destructive",
+      });
+    },
+    onSuccess: ({ saved, collection }) => {
+      // Signed out mid-save: nothing was written and this panel is gone.
+      if (!saved) return;
+
+      setSelectedId(collection?.id);
+
+      toast({
+        title: "Saved",
+        description: `New links will be pre-assigned to "${
+          collection?.pathname ?? "Unorganized"
+        }".`,
+        variant: "success",
+      });
+    },
+  });
+
+  // While the collections are loading there is nothing to match against yet,
+  // so the select shows its placeholder rather than a value that may change a
+  // moment later. A stored id that no longer resolves (e.g. the collection was
+  // deleted) falls back to the sentinel.
+  const value = isLoading
+    ? ""
+    : selectedId !== undefined &&
+        collections?.some((collection) => collection.id === selectedId)
+      ? String(selectedId)
+      : UNORGANIZED;
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="default-collection">Default collection</Label>
+      <p className="text-sm text-muted-foreground">
+        New links are pre-assigned to this collection in the popup.
+      </p>
+      {error ? (
+        <p className="text-sm text-red-600">
+          Could not load your collections. Please make sure the instance is
+          available.
+        </p>
+      ) : (
+        <SelectInput
+          id="default-collection"
+          value={value}
+          onChange={onSelect}
+          options={options}
+          placeholder={isLoading ? "Loading collections..." : "Unorganized"}
+          disabled={isLoading}
+          inFormField={false}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DefaultCollectionInput;

--- a/apps/extension/src/@/components/OptionsForm.tsx
+++ b/apps/extension/src/@/components/OptionsForm.tsx
@@ -33,6 +33,7 @@ import { AxiosError } from "axios";
 import { clearBookmarksMetadata } from "../lib/cache.ts";
 import { getSession } from "../lib/auth/auth.ts";
 import SelectInput, { SelectOption } from "./SelectInput.tsx";
+import DefaultCollectionInput from "./DefaultCollectionInput.tsx";
 
 interface OptionsFormProps {
   onSaved?: () => void;
@@ -72,6 +73,12 @@ const OptionsForm = ({
 
   const [signedInTo, setSignedInTo] = useState<string | undefined | null>(
     initialSignedInTo
+  );
+
+  // The config as it is currently stored, needed to talk to the account from
+  // the signed-in panel (and to show which default collection is selected).
+  const [savedConfig, setSavedConfig] = useState<configType | undefined>(
+    initialSignedInTo ? initialConfig : undefined
   );
 
   const form = useForm<optionsFormInput, unknown, optionsFormValues>({
@@ -114,6 +121,7 @@ const OptionsForm = ({
       await clearConfig();
       await clearBookmarksMetadata();
       setSignedInTo(null);
+      setSavedConfig(undefined);
       onCleared?.();
       return;
     },
@@ -184,17 +192,21 @@ const OptionsForm = ({
       }
     },
     onSuccess: async (values) => {
-      await saveConfig({
+      const config: configType = {
         baseUrl: values.baseUrl,
         defaultCollection: values.defaultCollection,
+        defaultCollectionId: values.defaultCollectionId,
         syncBookmarks: values.syncBookmarks,
         apiKey:
           values.method === "apiKey" && values.apiKey
             ? values.apiKey
             : values.data.response.token,
-      });
+      };
+
+      await saveConfig(config);
 
       setSignedInTo(values.baseUrl);
+      setSavedConfig(config);
 
       toast({
         title: "Saved",
@@ -212,7 +224,10 @@ const OptionsForm = ({
     (async () => {
       const cachedOptions = await getConfig();
       const instance = signedInInstance(cachedOptions);
-      if (instance) form.reset({ ...EMPTY_FORM, ...cachedOptions });
+      if (instance) {
+        form.reset({ ...EMPTY_FORM, ...cachedOptions });
+        setSavedConfig(cachedOptions);
+      }
       setSignedInTo(instance);
     })();
   }, [form, initialSignedInTo]);
@@ -231,6 +246,15 @@ const OptionsForm = ({
             {displayInstance(signedInTo)}
           </span>
         </p>
+
+        {savedConfig && (
+          <DefaultCollectionInput
+            baseUrl={savedConfig.baseUrl}
+            apiKey={savedConfig.apiKey}
+            initialCollectionId={savedConfig.defaultCollectionId}
+          />
+        )}
+
         <Button
           type="button"
           variant="outline"
@@ -356,26 +380,10 @@ const OptionsForm = ({
             </>
           )}
 
-          {/* Commented out fields */}
-          {/* 
-          <FormField
-            control={control}
-            name="defaultCollection"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Default collection</FormLabel>
-                <FormDescription>
-                  Default collection to add bookmarks to.
-                </FormDescription>
-                <FormControl>
-                  <Input placeholder="Unorganized" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          */}
+          {/* The default collection is configured from the signed-in panel,
+              since it needs a working connection to list the collections. */}
 
+          {/* Commented out fields */}
           {/* 
           <FormField
             control={control}

--- a/apps/extension/src/@/components/SelectInput.tsx
+++ b/apps/extension/src/@/components/SelectInput.tsx
@@ -9,17 +9,29 @@ import { useListboxKeys } from "../../hooks/useListboxKeys.ts";
 export type SelectOption = { value: string; label: string };
 
 type Props = {
+  /** Id of the trigger, so a standalone label can point at it. */
+  id?: string;
   value: string;
   onChange: (value: string) => void;
   options: SelectOption[];
   placeholder?: string;
+  disabled?: boolean;
+  /**
+   * Wraps the trigger in <FormControl> for the accessibility wiring of a
+   * react-hook-form field. Turn it off when the select is used as a standalone
+   * control, since <FormControl> requires a surrounding <FormField>.
+   */
+  inFormField?: boolean;
 };
 
 export default function SelectInput({
+  id,
   value,
   onChange,
   options,
   placeholder = "Select...",
+  disabled = false,
+  inFormField = true,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -36,24 +48,28 @@ export default function SelectInput({
 
   const selected = options.find((option) => option.value === value);
 
+  const trigger = (
+    <Button
+      id={id}
+      type="button"
+      variant="outline"
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      disabled={disabled}
+      className="w-full justify-between bg-neutral-100 dark:bg-neutral-900"
+    >
+      <span className="truncate text-left">
+        {selected?.label || placeholder}
+      </span>
+      <CaretSortIcon aria-hidden className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+    </Button>
+  );
+
   return (
     <div className="min-w-full">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <FormControl>
-            <Button
-              variant="outline"
-              aria-haspopup="listbox"
-              aria-expanded={open}
-              className="w-full justify-between bg-neutral-100 dark:bg-neutral-900"
-            >
-              {selected?.label || placeholder}
-              <CaretSortIcon
-                aria-hidden
-                className="ml-2 h-4 w-4 shrink-0 opacity-50"
-              />
-            </Button>
-          </FormControl>
+          {inFormField ? <FormControl>{trigger}</FormControl> : trigger}
         </PopoverTrigger>
 
         {open && (
@@ -64,7 +80,7 @@ export default function SelectInput({
             <div
               id={listId}
               role="listbox"
-              className="w-full overflow-y-auto p-1 text-foreground"
+              className="max-h-[250px] w-full overflow-y-auto p-1 text-foreground"
             >
               {options.map((option, index) => (
                 <div

--- a/apps/extension/src/@/lib/config.test.ts
+++ b/apps/extension/src/@/lib/config.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The real helpers talk to the extension's storage API, which does not exist
+// under the test runner. This stand-in keeps the async gap between reading and
+// writing, which is what makes interleaving observable in the first place.
+const store = new Map<string, string>();
+
+vi.mock('./utils.ts', () => ({
+  getStorageItem: async (key: string) => {
+    await Promise.resolve();
+    return store.get(key);
+  },
+  setStorageItem: async (key: string, value: string) => {
+    await Promise.resolve();
+    store.set(key, value);
+  },
+}));
+
+const { clearConfig, getConfig, saveConfig, updateConfig } = await import(
+  './config.ts'
+);
+
+const SIGNED_IN = {
+  baseUrl: 'https://links.example.com',
+  apiKey: 'secret-token',
+  defaultCollection: 'Unorganized',
+  syncBookmarks: false,
+};
+
+describe('updateConfig', () => {
+  beforeEach(async () => {
+    store.clear();
+    await saveConfig(SIGNED_IN);
+  });
+
+  it('merges the patch and leaves the rest of the config alone', async () => {
+    const updated = await updateConfig({
+      defaultCollection: 'Reading list',
+      defaultCollectionId: 7,
+    });
+
+    expect(updated).toMatchObject({
+      baseUrl: SIGNED_IN.baseUrl,
+      apiKey: SIGNED_IN.apiKey,
+      defaultCollection: 'Reading list',
+      defaultCollectionId: 7,
+    });
+    expect(await getConfig()).toMatchObject({ defaultCollectionId: 7 });
+  });
+
+  it('does not write once a sign-out has cleared the account', async () => {
+    const signOut = clearConfig();
+    const update = updateConfig({
+      defaultCollection: 'Reading list',
+      defaultCollectionId: 7,
+    });
+
+    await signOut;
+    expect(await update).toBeNull();
+
+    const config = await getConfig();
+    expect(config.apiKey).toBe('');
+    expect(config.baseUrl).toBe('');
+  });
+
+  it('leaves the account cleared when a sign-out lands mid-update', async () => {
+    const update = updateConfig({
+      defaultCollection: 'Reading list',
+      defaultCollectionId: 7,
+    });
+    const signOut = clearConfig();
+
+    await Promise.all([update, signOut]);
+
+    const config = await getConfig();
+    expect(config.apiKey).toBe('');
+    expect(config.baseUrl).toBe('');
+  });
+});

--- a/apps/extension/src/@/lib/config.ts
+++ b/apps/extension/src/@/lib/config.ts
@@ -15,8 +15,43 @@ export async function getConfig(): Promise<configType> {
   return config ? JSON.parse(config) : DEFAULTS;
 }
 
+// Writes are serialised so a read-modify-write can never interleave with
+// another write. Without this, a partial update that read the config just
+// before it was cleared would write the old credentials straight back.
+let writes: Promise<unknown> = Promise.resolve();
+
+function withConfigLock<T>(operation: () => Promise<T>): Promise<T> {
+  const result = writes.then(operation, operation);
+  writes = result.catch(() => undefined);
+  return result;
+}
+
 export async function saveConfig(config: configType) {
-  return await setStorageItem(CONFIG_KEY, JSON.stringify(config));
+  return await withConfigLock(() =>
+    setStorageItem(CONFIG_KEY, JSON.stringify(config))
+  );
+}
+
+/**
+ * Merges a partial update into the stored config.
+ *
+ * Returns the written config, or `null` when there is no configured account
+ * any more — the user signed out while the update was in flight, and writing
+ * the merged copy would resurrect the credentials they just cleared.
+ */
+export async function updateConfig(
+  patch: Partial<configType>
+): Promise<configType | null> {
+  return await withConfigLock(async () => {
+    const config = await getConfig();
+
+    if (!config.baseUrl || !config.apiKey) return null;
+
+    const updated = { ...config, ...patch };
+    await setStorageItem(CONFIG_KEY, JSON.stringify(updated));
+
+    return updated;
+  });
 }
 
 export async function isConfigured() {
@@ -30,13 +65,7 @@ export async function isConfigured() {
 }
 
 export async function clearConfig() {
-  return await setStorageItem(
-    CONFIG_KEY,
-    JSON.stringify({
-      baseUrl: '',
-      apiKey: '',
-      defaultCollection: 'Unorganized',
-      syncBookmarks: false,
-    })
+  return await withConfigLock(() =>
+    setStorageItem(CONFIG_KEY, JSON.stringify(DEFAULTS))
   );
 }

--- a/apps/extension/src/@/lib/validators/config.ts
+++ b/apps/extension/src/@/lib/validators/config.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const configSchema = z.object({
   baseUrl: z.string().url(),
   defaultCollection: z.string().optional().default('Unorganized'),
+  // Optional so configs stored before this field existed stay valid.
+  defaultCollectionId: z.number().optional(),
   apiKey: z.string(),
   syncBookmarks: z.boolean().optional().default(false),
 });

--- a/apps/extension/src/@/lib/validators/optionsForm.ts
+++ b/apps/extension/src/@/lib/validators/optionsForm.ts
@@ -6,6 +6,7 @@ export const optionsFormSchema = z.object({
   password: z.string(),
   syncBookmarks: z.boolean().default(false),
   defaultCollection: z.string().optional().default('Unorganized'),
+  defaultCollectionId: z.number().optional(),
   useApiKey: z.boolean().default(false),
   apiKey: z.string().optional(),
   method: z.enum(['username', 'apiKey']).default('username'),


### PR DESCRIPTION
## What does this PR do?

Adds a **Default collection** option to the browser extension settings. The selector is populated from the configured Linkwarden account, so only a collection that actually exists can be chosen. New links are then pre-assigned to that collection in the popup.

This replaces the commented-out, free-text `defaultCollection` field that sat unused in the options form.

**Changes**

- **`DefaultCollectionInput.tsx` (new)** — the selector itself. It lives in the signed-in panel of the settings, since listing the collections needs a working connection. Collections are labelled by their full pathname so nested collections with duplicate names stay unambiguous, and the choice is persisted as soon as it is made (the panel has no submit button of its own). Loading and request-failure states are handled.
- **`OptionsForm.tsx`** — keeps the stored config in state so the signed-in panel can hand the account's `baseUrl`/`apiKey` and the current default to the selector; clears it on sign-out. Removes the dead commented-out free-text field.
- **`lib/config.ts`** — config writes are serialised, and the new `updateConfig` performs its read-modify-write inside that critical section, returning `null` when no configured account is left. Without this, a default-collection save that raced a sign-out could write the cleared credentials back.
- **`validators/config.ts` / `validators/optionsForm.ts`** — persist the chosen collection's `id` (`defaultCollectionId`) alongside its existing `name` (`defaultCollection`). The id is optional, so configs written before this change stay valid.
- **`BookmarkForm.tsx`** — once the collections load, the configured default is resolved to its full object (`id`/`ownerId`/`name`) so the link is saved into exactly that collection. Matching prefers the stored id and falls back to the name for backward compatibility. A manual selection by the user is never overridden.
- **`SelectInput.tsx`** — gained optional `id`, `disabled` and `inFormField` props so it can be used as a standalone control outside a `FormField` (its `FormControl` wrapper requires one), plus a capped list height for long collection lists. Existing call sites are unaffected by the defaults.

**Why store the id**

Collection names are not unique across the hierarchy, and the API resolves a collection by name when no id is given. Storing the id guarantees the popup pre-fills — and the link is saved into — the exact collection the user picked, rather than a same-named one elsewhere in the tree.

**Note on HTTP instances**

This PR deliberately does not touch the `baseUrl` validation, which accepts `http:` URLs. That is pre-existing and, as far as I can tell, intentional for self-hosted deployments (localhost, LAN, TLS-terminating proxies), and the manifest agrees (`connect-src 'self' http: https:`). Happy to open a separate discussion if the project wants to tighten it.

## Visual Demo

Not included: the change was built and verified in a headless environment without a browser to load the unpacked extension into. The affected surfaces are the settings panel (new "Default collection" select below "Signed in to …") and the popup's collection field (now pre-filled).

## AI Assistance (Required)

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

- Claude Code

## What was verified by the author?

Automated checks run against this branch:

- `tsc --noEmit` passes.
- `vite build` succeeds.
- `eslint` reports the same 13 pre-existing problems as `main` (all in files this PR does not touch) — no new lint issues introduced.
- `apps/extension/src/@/lib/config.test.ts` (3 cases) covers the sign-out race described above; reverting just the serialisation turns it red.

- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes

## Submission Acknowledgement

- [x] I acknowledge that a decent size PR without self-review might be rejected
