### PR TITLE
Feat/editable publication date v2

### DIFF
--- a/apps/web/components/LinkDetails.tsx
+++ b/apps/web/components/LinkDetails.tsx
@@ -434,6 +434,44 @@ export default function LinkDetails({
 
           <br />
 
+          {user?.usePublicationDate && (
+            <>
+              <div className="relative">
+                <p className="text-sm mb-2 text-neutral relative w-fit flex justify-between">
+                  {t("publication_date")}
+                </p>
+                {mode === "view" ? (
+                  <div className="rounded-md p-2 bg-base-200">
+                    {new Intl.DateTimeFormat(undefined, {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    }).format(new Date(link.publishedAt || Date.now()))}
+                  </div>
+                ) : (
+                  <input
+                    type="date"
+                    required
+                    value={new Date(
+                      link.publishedAt || Date.now()
+                    )
+                      .toISOString()
+                      .slice(0, 10)}
+                    onChange={(e) => {
+                      if (!e.target.value) return;
+                      setLink({
+                        ...link,
+                        publishedAt: `${e.target.value}T12:00:00.000Z`,
+                      });
+                    }}
+                    className="w-full rounded-md p-2 border-neutral-content bg-base-200 focus:border-primary border-solid border outline-none duration-100"
+                  />
+                )}
+              </div>
+              <br />
+            </>
+          )}
+
           <div className="relative">
             <p className="text-sm mb-2 text-neutral relative w-fit flex justify-between">
               {t("description")}

--- a/apps/web/components/LinkViews/LinkComponents/LinkDate.tsx
+++ b/apps/web/components/LinkViews/LinkComponents/LinkDate.tsx
@@ -1,10 +1,14 @@
 import { LinkIncludingShortenedCollectionAndTags } from "@linkwarden/types/global";
 import React from "react";
+import { useUser } from "@linkwarden/router/user";
 
 function LinkDate({ link }: { link: LinkIncludingShortenedCollectionAndTags }) {
-  const formattedDate = new Date(
-    (link.importDate || link.createdAt) as string
-  ).toLocaleString("en-US", {
+  const { data: user } = useUser();
+  const date = user?.usePublicationDate
+    ? link.publishedAt || link.importDate || link.createdAt
+    : link.importDate || link.createdAt;
+
+  const formattedDate = new Date(date as string).toLocaleString("en-US", {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/apps/web/lib/api/controllers/links/getLinks.ts
+++ b/apps/web/lib/api/controllers/links/getLinks.ts
@@ -16,9 +16,22 @@ export default async function getLink(userId: number, query: LinkRequestQuery) {
   const { accessibleCollectionIds, memberCollectionIds } =
     await getAccessibleCollectionIds(userId);
 
-  let order: Order = { id: "desc" };
-  if (query.sort === Sort.DateNewestFirst) order = { id: "desc" };
-  else if (query.sort === Sort.DateOldestFirst) order = { id: "asc" };
+  const userPreference = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { usePublicationDate: true },
+  });
+  const usePublicationDate =
+    userPreference?.usePublicationDate ?? false;
+
+  let order: Order | Order[] = { id: "desc" };
+  if (query.sort === Sort.DateNewestFirst)
+    order = usePublicationDate
+      ? [{ publishedAt: "desc" }, { id: "desc" }]
+      : { id: "desc" };
+  else if (query.sort === Sort.DateOldestFirst)
+    order = usePublicationDate
+      ? [{ publishedAt: "asc" }, { id: "asc" }]
+      : { id: "asc" };
   else if (query.sort === Sort.NameAZ) order = { name: "asc" };
   else if (query.sort === Sort.NameZA) order = { name: "desc" };
 

--- a/apps/web/lib/api/controllers/links/linkId/updateLinkById.ts
+++ b/apps/web/lib/api/controllers/links/linkId/updateLinkById.ts
@@ -151,6 +151,9 @@ export default async function updateLinkById(
         name: data.name || "",
         url: data.url,
         description: data.description || "",
+        publishedAt: data.publishedAt
+          ? new Date(data.publishedAt)
+          : undefined,
         icon: data.icon,
         iconWeight: data.iconWeight,
         color: data.color,

--- a/apps/web/lib/api/controllers/migration/importFromLinkwarden.ts
+++ b/apps/web/lib/api/controllers/migration/importFromLinkwarden.ts
@@ -67,6 +67,9 @@ export default async function importFromLinkwarden(
                 name: link.name?.trim().slice(0, 254),
                 description: link.description?.trim().slice(0, 254),
                 importDate: new Date(link.importDate || link.createdAt),
+                publishedAt: new Date(
+                  link.publishedAt || link.importDate || link.createdAt
+                ),
                 collection: {
                   connect: {
                     id: newCollection.id,

--- a/apps/web/lib/api/controllers/search/searchLinks.ts
+++ b/apps/web/lib/api/controllers/search/searchLinks.ts
@@ -31,13 +31,29 @@ export default async function searchLinks({
 
   const resolveAccessCondition = async () => {
     if (!accessibleCollectionIdsPromise) return [];
-    const { accessibleCollectionIds } = await accessibleCollectionIdsPromise;
+    const { accessibleCollectionIds } =
+      await accessibleCollectionIdsPromise;
     return [{ collectionId: { in: accessibleCollectionIds } }];
   };
 
-  let order: Order = { id: "desc" };
-  if (query.sort === Sort.DateNewestFirst) order = { id: "desc" };
-  else if (query.sort === Sort.DateOldestFirst) order = { id: "asc" };
+  const userPreference = userId
+    ? await prisma.user.findUnique({
+        where: { id: userId },
+        select: { usePublicationDate: true },
+      })
+    : null;
+  const usePublicationDate =
+    userPreference?.usePublicationDate ?? false;
+
+  let order: Order | Order[] = { id: "desc" };
+  if (query.sort === Sort.DateNewestFirst)
+    order = usePublicationDate
+      ? [{ publishedAt: "desc" }, { id: "desc" }]
+      : { id: "desc" };
+  else if (query.sort === Sort.DateOldestFirst)
+    order = usePublicationDate
+      ? [{ publishedAt: "asc" }, { id: "asc" }]
+      : { id: "asc" };
   else if (query.sort === Sort.NameAZ) order = { name: "asc" };
   else if (query.sort === Sort.NameZA) order = { name: "desc" };
 
@@ -83,9 +99,13 @@ export default async function searchLinks({
       offset,
       sort:
         query.sort === Sort.DateNewestFirst
-          ? ["id:desc"]
+          ? usePublicationDate
+            ? ["publicationTimestamp:desc", "id:desc"]
+            : ["id:desc"]
           : query.sort === Sort.DateOldestFirst
-            ? ["id:asc"]
+            ? usePublicationDate
+              ? ["publicationTimestamp:asc", "id:asc"]
+              : ["id:asc"]
             : query.sort === Sort.NameAZ
               ? ["name:asc"]
               : query.sort === Sort.NameZA

--- a/apps/web/lib/api/controllers/users/userId/updateUserById.ts
+++ b/apps/web/lib/api/controllers/users/userId/updateUserById.ts
@@ -223,6 +223,7 @@ export default async function updateUserById(
       archiveAsWaybackMachine: data.archiveAsWaybackMachine,
       linksRouteTo: data.linksRouteTo,
       preventDuplicateLinks: data.preventDuplicateLinks,
+      usePublicationDate: data.usePublicationDate,
       referredBy:
         !user?.referredBy && data.referredBy ? data.referredBy : undefined,
       password:

--- a/apps/web/pages/settings/preference.tsx
+++ b/apps/web/pages/settings/preference.tsx
@@ -53,6 +53,9 @@ const Page: NextPageWithLayout = () => {
   const [preventDuplicateLinks, setPreventDuplicateLinks] = useState<boolean>(
     account.preventDuplicateLinks || false
   );
+  const [usePublicationDate, setUsePublicationDate] = useState<boolean>(
+    account.usePublicationDate ?? false
+  );
   const [archiveAsScreenshot, setArchiveAsScreenshot] = useState<boolean>(
     account.archiveAsScreenshot || false
   );
@@ -89,6 +92,7 @@ const Page: NextPageWithLayout = () => {
       setArchiveAsWaybackMachine(account.archiveAsWaybackMachine ?? false);
       setLinksRouteTo(account.linksRouteTo);
       setPreventDuplicateLinks(account.preventDuplicateLinks ?? false);
+      setUsePublicationDate(account.usePublicationDate ?? false);
       setAiTaggingMethod(account.aiTaggingMethod);
       setAiPredefinedTags(account.aiPredefinedTags);
       setAiTagExistingLinks(account.aiTagExistingLinks ?? false);
@@ -148,6 +152,7 @@ const Page: NextPageWithLayout = () => {
   const hasLinkChanges =
     !!account?.id &&
     (preventDuplicateLinks !== (account.preventDuplicateLinks ?? false) ||
+      usePublicationDate !== (account.usePublicationDate ?? false) ||
       linksRouteTo !== account.linksRouteTo);
 
   const saveAiSection = async () => {
@@ -226,6 +231,7 @@ const Page: NextPageWithLayout = () => {
       await updateUser.mutateAsync({
         ...baseUserPayload(),
         preventDuplicateLinks,
+        usePublicationDate,
         linksRouteTo,
       });
 
@@ -595,6 +601,13 @@ const Page: NextPageWithLayout = () => {
               label={t("prevent_duplicate_links")}
               state={preventDuplicateLinks}
               onClick={() => setPreventDuplicateLinks(!preventDuplicateLinks)}
+            />
+          </div>
+          <div className="mb-3">
+            <Checkbox
+              label={t("use_publication_date")}
+              state={usePublicationDate}
+              onClick={() => setUsePublicationDate(!usePublicationDate)}
             />
           </div>
           <p>{t("clicking_on_links_should")}</p>

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -174,6 +174,7 @@
   "archive_org_snapshot": "Archive.org Snapshot",
   "link_settings": "Link Settings",
   "prevent_duplicate_links": "Prevent duplicate links",
+  "use_publication_date": "Use publication dates for links",
   "clicking_on_links_should": "Clicking on Links should:",
   "open_original_content": "Open the original content",
   "open_pdf_if_available": "Open PDF, if available",

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -175,6 +175,7 @@
   "link_settings": "Link Settings",
   "prevent_duplicate_links": "Prevent duplicate links",
   "use_publication_date": "Use publication dates for links",
+  "publication_date": "Publication date",
   "clicking_on_links_should": "Clicking on Links should:",
   "open_original_content": "Open the original content",
   "open_pdf_if_available": "Open PDF, if available",

--- a/apps/web/public/locales/nl/common.json
+++ b/apps/web/public/locales/nl/common.json
@@ -175,6 +175,7 @@
   "link_settings": "Linkinstellingen",
   "prevent_duplicate_links": "Voorkom dubbele links",
   "use_publication_date": "Publicatiedatums voor links gebruiken",
+  "publication_date": "Publicatiedatum",
   "clicking_on_links_should": "Klikken op links moet:",
   "open_original_content": "Oorspronkelijke inhoud openen",
   "open_pdf_if_available": "PDF openen, indien beschikbaar",

--- a/apps/web/public/locales/nl/common.json
+++ b/apps/web/public/locales/nl/common.json
@@ -174,6 +174,7 @@
   "archive_org_snapshot": "Archive.org Momentopname",
   "link_settings": "Linkinstellingen",
   "prevent_duplicate_links": "Voorkom dubbele links",
+  "use_publication_date": "Publicatiedatums voor links gebruiken",
   "clicking_on_links_should": "Klikken op links moet:",
   "open_original_content": "Oorspronkelijke inhoud openen",
   "open_pdf_if_available": "PDF openen, indien beschikbaar",

--- a/apps/worker/workers/linkIndexing.ts
+++ b/apps/worker/workers/linkIndexing.ts
@@ -46,7 +46,7 @@ async function setupLinksIndexSchema() {
 
   const updateSortableAttributes = await meiliClient
     .index("links")
-    .updateSortableAttributes(["id", "name"]);
+    .updateSortableAttributes(["id", "name", "publicationTimestamp"]);
 
   await meiliClient
     .index("links")
@@ -139,6 +139,7 @@ export async function startIndexing(interval = 10) {
       tags: link.tags.map((t) => t.name),
       pinnedBy: link.pinnedBy.map((p) => p.id),
       creationTimestamp: Date.parse(link.createdAt.toISOString()) / 1000,
+      publicationTimestamp: Date.parse(link.publishedAt.toISOString()) / 1000,
       indexVersion: MEILI_INDEX_VERSION,
     }));
 

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -1,1 +1,1 @@
-export const MEILI_INDEX_VERSION = 1;
+export const MEILI_INDEX_VERSION = 2;

--- a/packages/lib/schemaValidation.ts
+++ b/packages/lib/schemaValidation.ts
@@ -153,6 +153,7 @@ export const UpdateLinkSchema = z.object({
   name: z.string().trim().max(2048).nullish(),
   url: z.string().trim().max(2048).nullish(),
   description: z.string().trim().max(2048).nullish(),
+  publishedAt: z.string().datetime().optional(),
   icon: z.string().trim().max(50).nullish(),
   iconWeight: z.string().trim().max(50).nullish(),
   color: z.string().trim().max(50).nullish(),

--- a/packages/lib/schemaValidation.ts
+++ b/packages/lib/schemaValidation.ts
@@ -87,6 +87,7 @@ export const UpdateUserSchema = () => {
     aiTagExistingLinks: z.boolean().optional(),
     locale: z.string().max(20).optional(),
     preventDuplicateLinks: z.boolean().optional(),
+    usePublicationDate: z.boolean().optional(),
     collectionOrder: z.array(z.number()).optional(),
     linksRouteTo: z.enum(LinksRouteTo).optional(),
     referredBy: z.string().max(100).nullish(),

--- a/packages/prisma/migrations/20260827080000_add_publication_date_fields/migration.sql
+++ b/packages/prisma/migrations/20260827080000_add_publication_date_fields/migration.sql
@@ -1,0 +1,16 @@
+-- Add the opt-in publication-date preference.
+ALTER TABLE "User"
+ADD COLUMN "usePublicationDate" BOOLEAN NOT NULL DEFAULT false;
+
+-- Add the publication date without changing the effective date of existing links.
+ALTER TABLE "Link"
+ADD COLUMN "publishedAt" TIMESTAMP(3);
+
+UPDATE "Link"
+SET "publishedAt" = "createdAt";
+
+ALTER TABLE "Link"
+ALTER COLUMN "publishedAt" SET DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "Link"
+ALTER COLUMN "publishedAt" SET NOT NULL;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -60,6 +60,7 @@ model User {
   readableLineHeight      String?               @default("1.8")
   readableLineWidth       String?               @default("normal")
   preventDuplicateLinks   Boolean               @default(false)
+  usePublicationDate     Boolean               @default(false)
   archiveAsScreenshot     Boolean               @default(true)
   archiveAsMonolith       Boolean               @default(true)
   archiveAsPDF            Boolean               @default(true)
@@ -188,6 +189,7 @@ model Link {
   indexVersion    Int?
   lastPreserved   DateTime?
   importDate      DateTime?
+  publishedAt     DateTime    @default(now())
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @default(now()) @updatedAt
 

--- a/packages/types/global.ts
+++ b/packages/types/global.ts
@@ -16,6 +16,7 @@ export interface LinkIncludingShortenedCollectionAndTags
     Link,
     | "id"
     | "createdAt"
+    | "publishedAt"
     | "collectionId"
     | "updatedAt"
     | "lastPreserved"
@@ -23,6 +24,7 @@ export interface LinkIncludingShortenedCollectionAndTags
   > {
   id?: number;
   createdAt?: string;
+  publishedAt?: string;
   importDate?: string;
   lastPreserved?: string | Date | null;
   collectionId?: number;


### PR DESCRIPTION
## What does this PR do?

Include an editable datefield and sort by this date. Only if the user chooses this in the settings. For safety an extra datafield is added to the table so other usage doesn't break. Of course, the original datefield could be used too I guess. 

- Fixes #1523 

## Visual Demo
<img width="1896" height="826" alt="afbeelding" src="https://github.com/user-attachments/assets/da048de5-0490-449a-9c46-706d39c6d73a" />

<img width="1888" height="826" alt="afbeelding" src="https://github.com/user-attachments/assets/2eba4682-0ebf-4485-86d3-e228a6100b7d" />

<img width="1898" height="830" alt="afbeelding" src="https://github.com/user-attachments/assets/8e5ce1c9-55e1-4335-8ecd-d867755471a6" />

## AI Assistance (Required)

This was vibecoded but I've been using this for some weeks now and I encountered no issues. 

#### AI usage level (check one)

- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [X] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?

 ChatGPT

## What was verified by the author?

<!-- Add what you personally checked to ensure correctness and safety. -->

- [ ] I reviewed **and** understood all AI/human generated code
- [X] I validated behavior locally (tests/manual verification)
- [ ] I checked edge cases and failure modes

## Submission Acknowledgement

- [X] I acknowledge that a decent size PR without self-review might be rejected