### PR TITLE
Significant changes to improve Browser Extension

### DIFF
--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -56,7 +56,7 @@ const targets: Record<ManifestTarget, TargetOptions> = {
  * into `version.xcconfig`, which the Xcode project reads as its base
  * configuration. Bump it here and nowhere else.
  */
-export const version = "1.5.7";
+export const version = "1.5.6";
 
 const icons = {
   "16": "16.png",

--- a/apps/extension/manifest.config.ts
+++ b/apps/extension/manifest.config.ts
@@ -56,7 +56,7 @@ const targets: Record<ManifestTarget, TargetOptions> = {
  * into `version.xcconfig`, which the Xcode project reads as its base
  * configuration. Bump it here and nowhere else.
  */
-export const version = "1.5.6";
+export const version = "1.5.7";
 
 const icons = {
   "16": "16.png",
@@ -93,10 +93,18 @@ export function buildManifest(target: ManifestTarget) {
       "scripting",
       "activeTab",
       "tabs",
+      "webNavigation",
       ...(options.bookmarks ? ["bookmarks"] : []),
       "contextMenus",
     ],
     host_permissions: ["<all_urls>"],
+    content_scripts: [
+      {
+        matches: ["http://*/*", "https://*/*"],
+        js: ["content.js"],
+        run_at: "document_start",
+      },
+    ],
     background: {
       ...(options.serviceWorker ? { service_worker: "background.js" } : {}),
       scripts: ["background.js"],
@@ -109,7 +117,8 @@ export function buildManifest(target: ManifestTarget) {
     ...(options.omnibox ? { omnibox: { keyword: "lk" } } : {}),
     commands: {
       _execute_action: {
-        suggested_key: { default: "Ctrl+Shift+F", mac: "Command+Shift+Y" },
+        suggested_key: { default: "Ctrl+D", mac: "Command+D" },
+        description: "Save the current page to Linkwarden",
       },
     },
     browser_specific_settings: options.browserSpecificSettings,

--- a/apps/extension/src/@/components/BookmarkForm.tsx
+++ b/apps/extension/src/@/components/BookmarkForm.tsx
@@ -84,6 +84,7 @@ const BookmarkForm = () => {
   const [config, setConfig] = useState<{
     baseUrl: string;
     defaultCollection: string;
+    defaultCollectionId?: number;
     apiKey: string;
     syncBookmarks: boolean;
   }>();
@@ -256,7 +257,10 @@ const BookmarkForm = () => {
       form.setValue("url", t.url ? t.url : "");
       form.setValue("name", t.title ? t.title : "");
       form.setValue("collection", {
-        name: c.defaultCollection,
+        ...(typeof c.defaultCollectionId === "number"
+          ? { id: c.defaultCollectionId }
+          : {}),
+        name: c.defaultCollection || "Unorganized",
       });
 
       const configured = await getIsConfigured();

--- a/apps/extension/src/@/components/BookmarkForm.tsx
+++ b/apps/extension/src/@/components/BookmarkForm.tsx
@@ -23,14 +23,21 @@ import {
   setStorageItem,
   updateBadge,
 } from "../lib/utils.ts";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
 import { getConfig, isConfigured as getIsConfigured } from "../lib/config.ts";
-import { checkLinkExists, postLink } from "../lib/actions/links.ts";
+import { Collection, getCollections } from "../lib/actions/collections.ts";
+import {
+  deleteLinks,
+  fetchLinkById,
+  findSavedLink,
+  findSavedLinks,
+  postLink,
+  updateLink,
+} from "../lib/actions/links.ts";
 import { AxiosError } from "axios";
 import { toast } from "../../hooks/useToast.ts";
 import { Toaster } from "./ui/Toaster.tsx";
-import { getCollections } from "../lib/actions/collections.ts";
 import { getShouldUseTagSearch, getTags } from "../lib/actions/tags.ts";
 import { ExternalLink } from "lucide-react";
 import { Checkbox } from "./ui/CheckBox.tsx";
@@ -39,6 +46,27 @@ import { Label } from "./ui/Label.tsx";
 // The popup is torn down every time it loses focus, so remember whether the
 // user had the extra options expanded and bring them back that way.
 const MORE_OPTIONS_KEY = "lw_more_options_open";
+
+function resolveCollection(
+  collection: bookmarkFormValues["collection"],
+  collections: Collection[] | undefined
+): bookmarkFormValues["collection"] {
+  if (!collection) return collection;
+  if (collection.id != null && collection.ownerId != null) return collection;
+
+  const match = collections?.find(
+    (item) =>
+      (collection.id != null && item.id === collection.id) ||
+      item.name === collection.name
+  );
+  if (!match) return collection;
+
+  return {
+    id: match.id,
+    ownerId: match.ownerId,
+    name: match.name,
+  };
+}
 
 const BookmarkForm = () => {
   const [openOptions, setOpenOptions] = useState<boolean>(false);
@@ -49,6 +77,9 @@ const BookmarkForm = () => {
 
   const [isConfigured, setIsConfigured] = useState(false);
   const [isDuplicate, setIsDuplicate] = useState(false);
+  const [savedLinkId, setSavedLinkId] = useState<number | null>(null);
+  const savedLinkIdRef = useRef<number | null>(null);
+  savedLinkIdRef.current = savedLinkId;
 
   const [config, setConfig] = useState<{
     baseUrl: string;
@@ -90,15 +121,45 @@ const BookmarkForm = () => {
 
   const { mutate: onSubmit, isPending } = useMutation({
     mutationFn: async (values: bookmarkFormValues) => {
+      const existingId = savedLinkIdRef.current;
+      let collection = values.collection;
+
+      if (
+        existingId != null &&
+        (collection?.id == null || collection.ownerId == null) &&
+        config?.baseUrl &&
+        config.apiKey
+      ) {
+        const list = (await getCollections(config.baseUrl, config.apiKey)).data
+          .response;
+        collection = resolveCollection(collection, list);
+      }
+
+      const payload = {
+        ...values,
+        collection,
+      };
+
+      if (existingId != null) {
+        await updateLink(
+          config?.baseUrl as string,
+          existingId,
+          uploadImage,
+          payload,
+          setState,
+          config?.apiKey as string
+        );
+        return "updated" as const;
+      }
+
       await postLink(
         config?.baseUrl as string,
         uploadImage,
-        values,
+        payload,
         setState,
         config?.apiKey as string
       );
-
-      return;
+      return "saved" as const;
     },
     onError: (error) => {
       console.error(error);
@@ -114,24 +175,71 @@ const BookmarkForm = () => {
         toast({
           title: "Error",
           description:
-            "There was an error while trying to save the link. Please try again.",
+            error instanceof Error
+              ? error.message
+              : "There was an error while trying to save the link. Please try again.",
           variant: "destructive",
         });
       }
       return;
     },
-    onSuccess: () => {
-      // Update badge to show link is saved
+    onSuccess: (result) => {
       updateBadge(tabInfo?.id, true);
+      setIsDuplicate(true);
       setTimeout(() => {
         window.close();
-        // I want to show some confirmation before it's closed...
       }, 3500);
       toast({
         title: "Success",
-        description: "Link saved successfully!",
+        description:
+          result === "updated"
+            ? "Link updated successfully!"
+            : "Link saved successfully!",
         variant: "success",
       });
+    },
+  });
+
+  const { mutate: onRemove, isPending: isRemoving } = useMutation({
+    mutationFn: async () => {
+      const c = await getConfig();
+      const tab = await getCurrentTabInfo();
+      const ids = new Set<number>();
+      if (savedLinkIdRef.current != null) ids.add(savedLinkIdRef.current);
+
+      const matches = await findSavedLinks(c.baseUrl, c.apiKey, tab.url);
+      if (Array.isArray(matches)) {
+        for (const link of matches) ids.add(link.id);
+      }
+
+      if (!c.baseUrl || !c.apiKey || ids.size === 0) {
+        throw new Error("Nothing to remove");
+      }
+
+      await deleteLinks(c.baseUrl, [...ids], c.apiKey, tab.url);
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "There was an error while trying to remove the link. Please try again.",
+        variant: "destructive",
+      });
+    },
+    onSuccess: () => {
+      setIsDuplicate(false);
+      setSavedLinkId(null);
+      updateBadge(tabInfo?.id, false);
+      toast({
+        title: "Removed",
+        description: "Link removed successfully!",
+        variant: "success",
+      });
+      setTimeout(() => {
+        window.close();
+      }, 1500);
     },
   });
 
@@ -156,9 +264,34 @@ const BookmarkForm = () => {
 
       if (!configured) return;
 
-      const duplicate = await checkLinkExists(c.baseUrl, c.apiKey, t.url);
-      setIsDuplicate(duplicate);
-      updateBadge(t.id, duplicate);
+      const found = await findSavedLink(c.baseUrl, c.apiKey, t.url);
+      if (found === null) return;
+      if (found === false) {
+        setIsDuplicate(false);
+        setSavedLinkId(null);
+        updateBadge(t.id, false);
+        return;
+      }
+      const saved = (await fetchLinkById(c.baseUrl, c.apiKey, found.id)) ?? found;
+      setIsDuplicate(true);
+      setSavedLinkId(saved.id);
+      updateBadge(t.id, true);
+      form.setValue("collection", {
+        id: saved.collection?.id,
+        ownerId: saved.collection?.ownerId,
+        name: saved.collection?.name || c.defaultCollection,
+      });
+      form.setValue(
+        "tags",
+        (saved.tags ?? [])
+          .filter((tag) => tag?.name)
+          .map((tag) => ({
+            ...(typeof tag.id === "number" ? { id: tag.id } : {}),
+            name: tag.name,
+          }))
+      );
+      form.setValue("name", saved.name || t.title || "");
+      form.setValue("description", saved.description || "");
     };
 
     setTabInformation();
@@ -205,6 +338,18 @@ const BookmarkForm = () => {
     },
     enabled: isConfigured,
   });
+
+  useEffect(() => {
+    if (!collections?.length) return;
+    const current = form.getValues("collection");
+    const resolved = resolveCollection(current, collections);
+    if (
+      resolved &&
+      (resolved.id !== current?.id || resolved.ownerId !== current?.ownerId)
+    ) {
+      form.setValue("collection", resolved);
+    }
+  }, [collections, form]);
 
   const { data: shouldUseTagSearch = false } = useQuery({
     queryKey: ["tag-search-support", config?.baseUrl, config?.apiKey],
@@ -383,9 +528,27 @@ const BookmarkForm = () => {
               {openOptions ? "Hide" : "More"} Options
             </Button>
 
-            <Button disabled={isPending} type="submit">
-              Save
-            </Button>
+            <div className="flex items-center gap-2">
+              {savedLinkId != null && (
+                <Button
+                  variant="destructive"
+                  type="button"
+                  disabled={isRemoving || isPending}
+                  onClick={() => onRemove()}
+                >
+                  {isRemoving ? "Removing..." : "Remove"}
+                </Button>
+              )}
+              <Button disabled={isPending || isRemoving} type="submit">
+                {isPending
+                  ? savedLinkId != null
+                    ? "Updating..."
+                    : "Saving..."
+                  : savedLinkId != null
+                    ? "Update"
+                    : "Save"}
+              </Button>
+            </div>
           </div>
 
           {isDuplicate && (

--- a/apps/extension/src/@/components/OptionsForm.tsx
+++ b/apps/extension/src/@/components/OptionsForm.tsx
@@ -33,6 +33,7 @@ import { AxiosError } from "axios";
 import { clearBookmarksMetadata } from "../lib/cache.ts";
 import { getSession } from "../lib/auth/auth.ts";
 import SelectInput, { SelectOption } from "./SelectInput.tsx";
+import { Checkbox } from "./ui/CheckBox.tsx";
 
 interface OptionsFormProps {
   onSaved?: () => void;
@@ -48,7 +49,36 @@ const EMPTY_FORM: optionsFormInput = {
   apiKey: "",
   syncBookmarks: false,
   defaultCollection: "Unorganized",
+  overrideBookmarkShortcut: true,
 };
+
+const ShortcutOverrideToggle = ({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => (
+  <label className="flex items-start gap-2 cursor-pointer">
+    <Checkbox
+      className="mt-0.5"
+      checked={checked}
+      onCheckedChange={(value) => {
+        if (value === "indeterminate") return;
+        onCheckedChange(value);
+      }}
+    />
+    <span className="space-y-1">
+      <span className="block text-sm font-medium leading-none">
+        Override Ctrl+D
+      </span>
+      <span className="block text-xs text-muted-foreground">
+        Open Linkwarden instead of the browser bookmark dialog. On Mac this is
+        Command+D.
+      </span>
+    </span>
+  </label>
+);
 
 const METHOD_OPTIONS: SelectOption[] = [
   { value: "username", label: "Username and Password" },
@@ -74,12 +104,22 @@ const OptionsForm = ({
     initialSignedInTo
   );
 
+  const [overrideBookmarkShortcut, setOverrideBookmarkShortcut] = useState(
+    initialConfig?.overrideBookmarkShortcut !== false
+  );
+
   const form = useForm<optionsFormInput, unknown, optionsFormValues>({
     resolver: zodResolver(optionsFormSchema),
     defaultValues: initialSignedInTo
       ? { ...EMPTY_FORM, ...initialConfig }
       : EMPTY_FORM,
   });
+
+  const persistOverride = async (enabled: boolean) => {
+    setOverrideBookmarkShortcut(enabled);
+    const config = await getConfig();
+    await saveConfig({ ...config, overrideBookmarkShortcut: enabled });
+  };
 
   const { mutate: onSignOut, isPending: signOutLoading } = useMutation({
     mutationFn: async () => {
@@ -110,6 +150,7 @@ const OptionsForm = ({
         apiKey: "",
         syncBookmarks: false,
         defaultCollection: "Unorganized",
+        overrideBookmarkShortcut,
       });
       await clearConfig();
       await clearBookmarksMetadata();
@@ -188,6 +229,7 @@ const OptionsForm = ({
         baseUrl: values.baseUrl,
         defaultCollection: values.defaultCollection,
         syncBookmarks: values.syncBookmarks,
+        overrideBookmarkShortcut,
         apiKey:
           values.method === "apiKey" && values.apiKey
             ? values.apiKey
@@ -214,6 +256,9 @@ const OptionsForm = ({
       const instance = signedInInstance(cachedOptions);
       if (instance) form.reset({ ...EMPTY_FORM, ...cachedOptions });
       setSignedInTo(instance);
+      setOverrideBookmarkShortcut(
+        cachedOptions.overrideBookmarkShortcut !== false
+      );
     })();
   }, [form, initialSignedInTo]);
 
@@ -231,6 +276,12 @@ const OptionsForm = ({
             {displayInstance(signedInTo)}
           </span>
         </p>
+        <ShortcutOverrideToggle
+          checked={overrideBookmarkShortcut}
+          onCheckedChange={(enabled) => {
+            void persistOverride(enabled);
+          }}
+        />
         <Button
           type="button"
           variant="outline"
@@ -397,6 +448,13 @@ const OptionsForm = ({
             )}
           />
           */}
+
+          <ShortcutOverrideToggle
+            checked={overrideBookmarkShortcut}
+            onCheckedChange={(enabled) => {
+              void persistOverride(enabled);
+            }}
+          />
 
           <div className="flex justify-end pb-2">
             <Button disabled={isPending} type="submit">

--- a/apps/extension/src/@/components/OptionsForm.tsx
+++ b/apps/extension/src/@/components/OptionsForm.tsx
@@ -18,7 +18,7 @@ import {
 } from "../lib/validators/optionsForm.ts";
 import { Input } from "./ui/Input.tsx";
 import { Button } from "./ui/Button.tsx";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
   clearConfig,
@@ -34,6 +34,8 @@ import { clearBookmarksMetadata } from "../lib/cache.ts";
 import { getSession } from "../lib/auth/auth.ts";
 import SelectInput, { SelectOption } from "./SelectInput.tsx";
 import { Checkbox } from "./ui/CheckBox.tsx";
+import CollectionInput from "./CollectionInput.tsx";
+import { getCollections } from "../lib/actions/collections.ts";
 
 interface OptionsFormProps {
   onSaved?: () => void;
@@ -107,6 +109,13 @@ const OptionsForm = ({
   const [overrideBookmarkShortcut, setOverrideBookmarkShortcut] = useState(
     initialConfig?.overrideBookmarkShortcut !== false
   );
+  const [defaultCollection, setDefaultCollection] = useState(
+    initialConfig?.defaultCollection || "Unorganized"
+  );
+  const [defaultCollectionId, setDefaultCollectionId] = useState<
+    number | undefined
+  >(initialConfig?.defaultCollectionId);
+  const [openDefaultCollection, setOpenDefaultCollection] = useState(false);
 
   const form = useForm<optionsFormInput, unknown, optionsFormValues>({
     resolver: zodResolver(optionsFormSchema),
@@ -119,6 +128,20 @@ const OptionsForm = ({
     setOverrideBookmarkShortcut(enabled);
     const config = await getConfig();
     await saveConfig({ ...config, overrideBookmarkShortcut: enabled });
+  };
+
+  const persistDefaultCollection = async (collection: {
+    id?: number;
+    name: string;
+  }) => {
+    setDefaultCollection(collection.name);
+    setDefaultCollectionId(collection.id);
+    const config = await getConfig();
+    await saveConfig({
+      ...config,
+      defaultCollection: collection.name,
+      defaultCollectionId: collection.id,
+    });
   };
 
   const { mutate: onSignOut, isPending: signOutLoading } = useMutation({
@@ -227,7 +250,8 @@ const OptionsForm = ({
     onSuccess: async (values) => {
       await saveConfig({
         baseUrl: values.baseUrl,
-        defaultCollection: values.defaultCollection,
+        defaultCollection,
+        defaultCollectionId,
         syncBookmarks: values.syncBookmarks,
         overrideBookmarkShortcut,
         apiKey:
@@ -259,11 +283,28 @@ const OptionsForm = ({
       setOverrideBookmarkShortcut(
         cachedOptions.overrideBookmarkShortcut !== false
       );
+      setDefaultCollection(cachedOptions.defaultCollection || "Unorganized");
+      setDefaultCollectionId(cachedOptions.defaultCollectionId);
     })();
   }, [form, initialSignedInTo]);
 
   const { handleSubmit, control, watch } = form;
   const method = watch("method");
+
+  const {
+    data: collections,
+    isLoading: loadingCollections,
+  } = useQuery({
+    queryKey: ["settings-collections", signedInTo],
+    queryFn: async () => {
+      const config = await getConfig();
+      const response = await getCollections(config.baseUrl, config.apiKey);
+      return response.data.response.sort((a, b) =>
+        a.pathname.localeCompare(b.pathname)
+      );
+    },
+    enabled: Boolean(signedInTo),
+  });
 
   if (signedInTo === undefined) return null;
 
@@ -282,6 +323,35 @@ const OptionsForm = ({
             void persistOverride(enabled);
           }}
         />
+        <Form {...form}>
+          <FormField
+            control={control}
+            name="defaultCollection"
+            render={() => (
+              <FormItem>
+                <FormLabel>Default collection</FormLabel>
+                <FormDescription>
+                  New bookmarks are saved to this collection.
+                </FormDescription>
+                <CollectionInput
+                  value={{
+                    id: defaultCollectionId,
+                    name: defaultCollection,
+                  }}
+                  onChange={(collection) => {
+                    void persistDefaultCollection(collection);
+                  }}
+                  collections={collections}
+                  isLoading={loadingCollections}
+                  open={openDefaultCollection}
+                  onOpenChange={setOpenDefaultCollection}
+                  fullScreen={false}
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </Form>
         <Button
           type="button"
           variant="outline"

--- a/apps/extension/src/@/lib/actions/links.ts
+++ b/apps/extension/src/@/lib/actions/links.ts
@@ -66,6 +66,62 @@ export async function postLinkFetch(
   });
 }
 
+export async function updateLink(
+  baseUrl: string,
+  id: number,
+  uploadImage: boolean,
+  data: bookmarkFormValues,
+  setState: (state: "capturing" | "uploading" | null) => void,
+  apiKey: string
+) {
+  if (!data.collection?.id || data.collection.ownerId == null) {
+    throw new Error("Please select a collection.");
+  }
+
+  const url = `${baseUrl}/api/v1/links/${id}`;
+  const body = {
+    id,
+    name: data.name,
+    url: data.url,
+    description: data.description,
+    collection: {
+      id: data.collection.id,
+      ownerId: data.collection.ownerId,
+    },
+    tags: (data.tags ?? []).map((tag) => ({
+      ...(typeof tag.id === "number" ? { id: tag.id } : {}),
+      name: tag.name,
+    })),
+  };
+
+  const link = await axios.put(url, body, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (uploadImage) {
+    setState("capturing");
+    const screenshot = await captureScreenshot();
+    setState("uploading");
+
+    const archiveUrl = `${baseUrl}/api/v1/archives/${id}?format=0`;
+    const formData = new FormData();
+    formData.append("file", screenshot, "screenshot.png");
+
+    await axios.post(archiveUrl, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    setState(null);
+  }
+
+  return link;
+}
+
 export async function updateLinkFetch(
   baseUrl: string,
   id: number,
@@ -84,19 +140,108 @@ export async function updateLinkFetch(
   });
 }
 
+function apiRoot(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function authHeaders(apiKey: string) {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function axiosErrorMessage(error: unknown, fallback: string) {
+  if (axios.isAxiosError(error)) {
+    const response = error.response?.data?.response;
+    if (typeof response === "string" && response.trim()) return response;
+    if (error.response?.status) {
+      return `${fallback} (HTTP ${error.response.status})`;
+    }
+  }
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+async function deleteOnServer(
+  baseUrl: string,
+  ids: number[],
+  apiKey: string
+) {
+  const root = apiRoot(baseUrl);
+  const headers = authHeaders(apiKey);
+  let lastError: unknown;
+
+  for (const id of ids) {
+    try {
+      await axios.delete(`${root}/api/v1/links/${id}`, { headers });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  // 1.5.6 / v2.5 also deletes via the collection route. Always try it so a
+  // no-op or GET-converted /links/:id DELETE cannot look like success.
+  try {
+    await axios.delete(`${root}/api/v1/links`, {
+      headers,
+      data: { linkIds: ids },
+    });
+  } catch (error) {
+    lastError = error;
+  }
+
+  return lastError;
+}
+
+export async function deleteLinks(
+  baseUrl: string,
+  ids: number[],
+  apiKey: string,
+  linkUrl?: string
+) {
+  const unique = [...new Set(ids)].filter((id) => Number.isInteger(id) && id > 0);
+  if (unique.length === 0) {
+    throw new Error("Nothing to remove");
+  }
+
+  const visibleByGet = new Set<number>();
+  for (const id of unique) {
+    if (await fetchLinkById(baseUrl, apiKey, id)) visibleByGet.add(id);
+  }
+
+  const lastError = await deleteOnServer(baseUrl, unique, apiKey);
+
+  const remainingGet: number[] = [];
+  for (const id of visibleByGet) {
+    if (await fetchLinkById(baseUrl, apiKey, id)) remainingGet.push(id);
+  }
+  if (remainingGet.length > 0) {
+    throw new Error(
+      axiosErrorMessage(lastError, "The server did not remove the link.")
+    );
+  }
+
+  const getConfirmedAllGone =
+    visibleByGet.size === unique.length && remainingGet.length === 0;
+
+  if (linkUrl && !getConfirmedAllGone) {
+    const leftover = await findSavedLinks(baseUrl, apiKey, linkUrl);
+    if (Array.isArray(leftover) && leftover.some((link) => unique.includes(link.id))) {
+      throw new Error(
+        axiosErrorMessage(lastError, "The server did not remove the link.")
+      );
+    }
+  }
+}
+
 export async function deleteLinkFetch(
   baseUrl: string,
   id: number,
   apiKey: string
 ) {
-  const url = `${baseUrl}/api/v1/links/${id}`;
-
-  return await fetch(url, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  await deleteLinks(baseUrl, [id], apiKey);
+  return new Response(null, { status: 200 });
 }
 
 // export async function getLinksFetch(
@@ -112,31 +257,207 @@ export async function deleteLinkFetch(
 //   return await response.json();
 // }
 
-export async function checkLinkExists(
+type SavedLink = {
+  id: number;
+  url?: string | null;
+  name?: string | null;
+  description?: string | null;
+  collection?: {
+    id?: number;
+    ownerId?: number;
+    name?: string;
+  } | null;
+  tags?: { id?: number; name: string }[] | null;
+};
+
+export async function fetchLinkById(
+  baseUrl: string,
+  apiKey: string,
+  id: number
+): Promise<SavedLink | null> {
+  const response = await fetch(`${apiRoot(baseUrl)}/api/v1/links/${id}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  if (!response.ok) return null;
+
+  const json = await response.json();
+  const link = json?.response;
+  const parsedId = numericId(link?.id);
+  if (!link || parsedId == null) return null;
+  return { ...link, id: parsedId } as SavedLink;
+}
+
+function linksFromPayload(json: unknown): SavedLink[] | null {
+  if (!json || typeof json !== "object") return null;
+  const payload = json as Record<string, unknown>;
+  const data = payload.data as Record<string, unknown> | unknown[] | undefined;
+
+  if (Array.isArray(data)) return [];
+  if (data && Array.isArray(data.links)) return data.links as SavedLink[];
+  if (Array.isArray(payload.response)) return payload.response as SavedLink[];
+  if (
+    payload.response &&
+    typeof payload.response === "object" &&
+    Array.isArray((payload.response as { links?: unknown }).links)
+  ) {
+    return (payload.response as { links: SavedLink[] }).links;
+  }
+  return null;
+}
+
+async function fetchLinkResults(
+  url: string,
+  apiKey: string
+): Promise<SavedLink[] | null> {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  if (!response.ok) return null;
+  return linksFromPayload(await response.json());
+}
+
+function numericId(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) return Number(value);
+  return null;
+}
+
+function normalizeLink(link: SavedLink): SavedLink | null {
+  const id = numericId(link.id);
+  if (id == null) return null;
+  return { ...link, id };
+}
+
+function canonicalizeUrl(linkUrl: string): string | null {
+  const noHash = linkUrl.trim().split("#")[0];
+  if (!noHash) return null;
+  try {
+    const parsed = new URL(noHash);
+    parsed.hash = "";
+    parsed.username = "";
+    parsed.password = "";
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+    return parsed.href;
+  } catch {
+    return noHash.replace(/\/+$/, "") || null;
+  }
+}
+
+function urlsMatchExactly(savedUrl: string, tabUrl: string): boolean {
+  const saved = canonicalizeUrl(savedUrl);
+  const tab = canonicalizeUrl(tabUrl);
+  return !!saved && !!tab && saved === tab;
+}
+
+function urlPathnameIsEmpty(linkUrl: string): boolean {
+  try {
+    const pathname = new URL(linkUrl).pathname;
+    return pathname === "" || pathname === "/";
+  } catch {
+    return true;
+  }
+}
+
+async function confirmExactMatches(
+  baseUrl: string,
+  apiKey: string,
+  links: SavedLink[],
+  tabUrl: string
+): Promise<SavedLink[]> {
+  const matches: SavedLink[] = [];
+  const seen = new Set<number>();
+  let hydrates = 0;
+
+  for (const raw of links) {
+    const link = normalizeLink(raw);
+    if (!link || seen.has(link.id)) continue;
+
+    // Prisma/Meilisearch `contains` matches https://vg.no against
+    // https://vg.no/otherarticle. Different paths are never "this page".
+    if (link.url && !urlsMatchExactly(link.url, tabUrl)) continue;
+
+    let resolved = link;
+    const searchUrlLooksPartial = !link.url || urlPathnameIsEmpty(link.url);
+    if (searchUrlLooksPartial && hydrates < 10) {
+      hydrates += 1;
+      const full = await fetchLinkById(baseUrl, apiKey, link.id);
+      if (full) resolved = full;
+    }
+
+    if (!resolved.url || !urlsMatchExactly(resolved.url, tabUrl)) continue;
+    seen.add(link.id);
+    matches.push(resolved);
+  }
+
+  return matches;
+}
+
+export async function findSavedLinks(
   baseUrl: string,
   apiKey: string,
   linkUrl: string | undefined
-): Promise<boolean> {
+): Promise<SavedLink[] | false | null> {
   if (!baseUrl || !apiKey || !linkUrl) {
     return false;
   }
 
-  const url =
-    `${baseUrl}/api/v1/search?sort=0&searchQueryString=` +
-    encodeURIComponent(`url:${linkUrl}`);
+  const queryUrl = canonicalizeUrl(linkUrl) ?? linkUrl;
+  const encoded = encodeURIComponent(queryUrl);
+
+  // 1.5.6 Prisma search treats the whole string as contains-text, so
+  // `url:https://...` never matches. Send the raw URL first. Keep the
+  // `url:` form and the older /links route for Meilisearch and pre-search APIs.
+  const queries = [
+    `${apiRoot(baseUrl)}/api/v1/search?sort=0&searchQueryString=${encoded}`,
+    `${apiRoot(baseUrl)}/api/v1/search?sort=0&searchQueryString=${encodeURIComponent(`url:${queryUrl}`)}`,
+    `${apiRoot(baseUrl)}/api/v1/links?sort=0&searchQueryString=${encoded}&searchByUrl=true`,
+  ];
 
   try {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
-    });
-
-    const { data } = await response.json();
-
-    return !!data && data.links?.length > 0;
+    let sawSuccess = false;
+    for (const url of queries) {
+      const links = await fetchLinkResults(url, apiKey);
+      if (links === null) continue;
+      sawSuccess = true;
+      const matches = await confirmExactMatches(
+        baseUrl,
+        apiKey,
+        links,
+        linkUrl
+      );
+      if (matches.length) return matches;
+    }
+    // A domain-wide contains hit is a successful lookup of *other* pages,
+    // not a failed request. Do not leave a stale checkmark.
+    return sawSuccess ? false : null;
   } catch (error) {
     console.error(error);
-    return false;
+    return null;
   }
+}
+
+export async function findSavedLink(
+  baseUrl: string,
+  apiKey: string,
+  linkUrl: string | undefined
+): Promise<SavedLink | false | null> {
+  const found = await findSavedLinks(baseUrl, apiKey, linkUrl);
+  if (!found) return found;
+  return found[0];
+}
+
+export async function checkLinkExists(
+  baseUrl: string,
+  apiKey: string,
+  linkUrl: string | undefined
+): Promise<boolean | null> {
+  const found = await findSavedLink(baseUrl, apiKey, linkUrl);
+  if (found === null) return null;
+  return found !== false;
 }

--- a/apps/extension/src/@/lib/badge.ts
+++ b/apps/extension/src/@/lib/badge.ts
@@ -1,0 +1,85 @@
+import { checkLinkExists } from "./actions/links.ts";
+import { getConfig, isConfigured } from "./config.ts";
+import { getBrowser, updateBadge } from "./utils.ts";
+
+const MAX_URL_RETRIES = 8;
+const badgeHints = new Map<number, string>();
+const badgeRetries = new Map<number, number>();
+const scheduledTabs = new Set<number>();
+
+export function isCheckableUrl(url: string | undefined): url is string {
+  return !!url && (url.startsWith("http://") || url.startsWith("https://"));
+}
+
+function isPendingTabUrl(url: string | undefined, status?: string) {
+  return (
+    status === "loading" ||
+    !url ||
+    url === "about:blank" ||
+    url === "about:newtab"
+  );
+}
+
+/**
+ * `tabs.onActivated` fires before the tab URL is populated, and
+ * `tabs.onUpdated` can report `status: "complete"` before `tab.url` is set.
+ * Keep the last http(s) URL we saw for this tab and retry until it shows up,
+ * otherwise the checkmark only appears after switching away and back.
+ *
+ * Coalesce with queueMicrotask instead of setTimeout: MV3 service workers
+ * in Brave/Chrome often drop those timers before they run.
+ */
+export function scheduleTabBadge(tabId: number | undefined, url?: string) {
+  if (!tabId) return;
+  if (isCheckableUrl(url)) {
+    badgeHints.set(tabId, url);
+  }
+  if (scheduledTabs.has(tabId)) return;
+  scheduledTabs.add(tabId);
+  queueMicrotask(() => {
+    scheduledTabs.delete(tabId);
+    const hint = badgeHints.get(tabId);
+    void updateTabBadge(tabId, hint);
+  });
+}
+
+export async function updateTabBadge(tabId: number | undefined, url?: string) {
+  if (!tabId) return;
+
+  if (!(await isConfigured())) {
+    badgeRetries.delete(tabId);
+    await updateBadge(tabId, false);
+    return;
+  }
+
+  let tabUrl = isCheckableUrl(url) ? url : undefined;
+  let tab: chrome.tabs.Tab | undefined;
+  try {
+    tab = await getBrowser().tabs.get(tabId);
+    if (!tabUrl) tabUrl = tab.url;
+  } catch {
+    badgeRetries.delete(tabId);
+    return;
+  }
+
+  if (!isCheckableUrl(tabUrl)) {
+    const attempt = badgeRetries.get(tabId) ?? 0;
+    if (isPendingTabUrl(tabUrl, tab.status) && attempt < MAX_URL_RETRIES) {
+      badgeRetries.set(tabId, attempt + 1);
+      setTimeout(() => {
+        void updateTabBadge(tabId);
+      }, 100 * (attempt + 1));
+      return;
+    }
+    badgeRetries.delete(tabId);
+    await updateBadge(tabId, false);
+    return;
+  }
+
+  badgeRetries.delete(tabId);
+
+  const { baseUrl, apiKey } = await getConfig();
+  const exists = await checkLinkExists(baseUrl, apiKey, tabUrl);
+  if (exists === null) return;
+  await updateBadge(tabId, exists);
+}

--- a/apps/extension/src/@/lib/config.ts
+++ b/apps/extension/src/@/lib/config.ts
@@ -6,13 +6,19 @@ const DEFAULTS: configType = {
   apiKey: '',
   defaultCollection: 'Unorganized',
   syncBookmarks: false,
+  overrideBookmarkShortcut: true,
 };
 
 const CONFIG_KEY = 'linkwarden_config';
 
 export async function getConfig(): Promise<configType> {
   const config = await getStorageItem(CONFIG_KEY);
-  return config ? JSON.parse(config) : DEFAULTS;
+  if (!config) return { ...DEFAULTS };
+  try {
+    return { ...DEFAULTS, ...JSON.parse(config) };
+  } catch {
+    return { ...DEFAULTS };
+  }
 }
 
 export async function saveConfig(config: configType) {
@@ -30,13 +36,12 @@ export async function isConfigured() {
 }
 
 export async function clearConfig() {
+  const current = await getConfig();
   return await setStorageItem(
     CONFIG_KEY,
     JSON.stringify({
-      baseUrl: '',
-      apiKey: '',
-      defaultCollection: 'Unorganized',
-      syncBookmarks: false,
+      ...DEFAULTS,
+      overrideBookmarkShortcut: current.overrideBookmarkShortcut,
     })
   );
 }

--- a/apps/extension/src/@/lib/utils.ts
+++ b/apps/extension/src/@/lib/utils.ts
@@ -84,10 +84,28 @@ export async function updateBadge(
   const action = browser.action ?? browser.browserAction;
   if (!action) return;
 
+  const text = linkExists ? "✓" : "";
+  const background = "#4688F1";
+  const foreground = "#FFFFFF";
+
+  action.setBadgeText({ tabId, text });
   if (linkExists) {
-    action.setBadgeText({ tabId, text: "✓" });
-    action.setBadgeBackgroundColor({ tabId, color: "#98c0ff" });
-  } else {
-    action.setBadgeText({ tabId, text: "" });
+    action.setBadgeBackgroundColor({ tabId, color: background });
+    action.setBadgeTextColor?.({ tabId, color: foreground });
+  }
+
+  // Brave (and some Chromium builds) do not repaint a tab-scoped toolbar
+  // badge until the tab is deactivated and selected again. If this tab is
+  // showing, also set the window badge so the checkmark appears immediately.
+  try {
+    const tab = await browser.tabs.get(tabId);
+    if (!tab.active) return;
+    action.setBadgeText({ text });
+    if (linkExists) {
+      action.setBadgeBackgroundColor({ color: background });
+      action.setBadgeTextColor?.({ color: foreground });
+    }
+  } catch {
+    // Tab was closed.
   }
 }

--- a/apps/extension/src/@/lib/validators/config.ts
+++ b/apps/extension/src/@/lib/validators/config.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const configSchema = z.object({
   baseUrl: z.string().url(),
   defaultCollection: z.string().optional().default('Unorganized'),
+  defaultCollectionId: z.number().optional(),
   apiKey: z.string(),
   syncBookmarks: z.boolean().optional().default(false),
   overrideBookmarkShortcut: z.boolean().optional().default(true),

--- a/apps/extension/src/@/lib/validators/config.ts
+++ b/apps/extension/src/@/lib/validators/config.ts
@@ -5,6 +5,7 @@ export const configSchema = z.object({
   defaultCollection: z.string().optional().default('Unorganized'),
   apiKey: z.string(),
   syncBookmarks: z.boolean().optional().default(false),
+  overrideBookmarkShortcut: z.boolean().optional().default(true),
 });
 
 export type configType = z.infer<typeof configSchema>;

--- a/apps/extension/src/@/lib/validators/optionsForm.ts
+++ b/apps/extension/src/@/lib/validators/optionsForm.ts
@@ -5,6 +5,7 @@ export const optionsFormSchema = z.object({
   username: z.string(),
   password: z.string(),
   syncBookmarks: z.boolean().default(false),
+  overrideBookmarkShortcut: z.boolean().default(true),
   defaultCollection: z.string().optional().default('Unorganized'),
   useApiKey: z.boolean().default(false),
   apiKey: z.string().optional(),

--- a/apps/extension/src/@/lib/validators/optionsForm.ts
+++ b/apps/extension/src/@/lib/validators/optionsForm.ts
@@ -7,6 +7,7 @@ export const optionsFormSchema = z.object({
   syncBookmarks: z.boolean().default(false),
   overrideBookmarkShortcut: z.boolean().default(true),
   defaultCollection: z.string().optional().default('Unorganized'),
+  defaultCollectionId: z.number().optional(),
   useApiKey: z.boolean().default(false),
   apiKey: z.string().optional(),
   method: z.enum(['username', 'apiKey']).default('username'),

--- a/apps/extension/src/pages/Background/index.ts
+++ b/apps/extension/src/pages/Background/index.ts
@@ -231,7 +231,10 @@ async function genericOnClick(
                   name: tab.title || "",
                   description: tab.title || "",
                   collection: {
-                    name: config.defaultCollection,
+                    ...(typeof config.defaultCollectionId === "number"
+                      ? { id: config.defaultCollectionId }
+                      : {}),
+                    name: config.defaultCollection || "Unorganized",
                   },
                   tags: [],
                 },
@@ -263,7 +266,10 @@ async function genericOnClick(
             {
               url: tab.url,
               collection: {
-                name: "Unorganized",
+                ...(typeof config.defaultCollectionId === "number"
+                  ? { id: config.defaultCollectionId }
+                  : {}),
+                name: config.defaultCollection || "Unorganized",
               },
               tags: [],
               name: tab.title,

--- a/apps/extension/src/pages/Background/index.ts
+++ b/apps/extension/src/pages/Background/index.ts
@@ -7,6 +7,7 @@ import {
 } from "../../@/lib/utils.ts";
 // import BookmarkTreeNode = chrome.bookmarks.BookmarkTreeNode;
 import { getConfig, isConfigured } from "../../@/lib/config.ts";
+import { scheduleTabBadge } from "../../@/lib/badge.ts";
 import {
   // deleteLinkFetch,
   // updateLinkFetch,
@@ -222,7 +223,7 @@ async function genericOnClick(
           !tab.url.startsWith("about:")
         ) {
           try {
-            if (new URL(tab.url))
+            if (new URL(tab.url)) {
               await postLinkFetch(
                 config.baseUrl,
                 {
@@ -236,6 +237,8 @@ async function genericOnClick(
                 },
                 config.apiKey
               );
+              await updateBadge(tab.id, true);
+            }
           } catch (error) {
             console.error(`Failed to save tab: ${tab.url}`, error);
           }
@@ -274,6 +277,7 @@ async function genericOnClick(
           newLinkUrl.bookmarkId = tab.id?.toString();
 
           await saveBookmarkMetadata(newLinkUrl);
+          await updateBadge(tab.id, true);
         } catch (error) {
           console.error(error);
         }
@@ -298,16 +302,123 @@ browser.runtime.onInstalled.addListener(async function () {
     title: "Save all tabs to Linkwarden",
     contexts: ["page"],
   });
+
+  const { id: tabId, url } = await getCurrentTabInfo();
+  scheduleTabBadge(tabId, url);
 });
 
-browser.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
-  if (!changeInfo.url) return;
-  try {
-    await updateBadge(tabId, false);
-  } catch (error) {
-    console.error(`Error clearing the badge of tab ${tabId}:`, error);
-  }
+function onNavigation(details: {
+  tabId: number;
+  frameId: number;
+  url: string;
+}) {
+  if (details.frameId !== 0) return;
+  scheduleTabBadge(details.tabId, details.url);
+}
+
+// onActivated alone is not enough: it does not fire on same-tab navigation,
+// and when it does fire the tab URL is often still blank. Navigation events
+// plus a retry in scheduleTabBadge are what make the checkmark appear as soon
+// as you land on a saved page.
+browser.tabs.onActivated.addListener(({ tabId }) => {
+  scheduleTabBadge(tabId);
 });
+
+browser.tabs.onCreated.addListener((tab) => {
+  scheduleTabBadge(tab.id, tab.url);
+});
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (!changeInfo.url && changeInfo.status !== "complete") return;
+  scheduleTabBadge(tabId, changeInfo.url ?? tab?.url);
+});
+
+if (hasAPI("webNavigation.onCommitted")) {
+  browser.webNavigation.onCommitted.addListener(onNavigation);
+}
+if (hasAPI("webNavigation.onCompleted")) {
+  browser.webNavigation.onCompleted.addListener(onNavigation);
+}
+if (hasAPI("webNavigation.onHistoryStateUpdated")) {
+  browser.webNavigation.onHistoryStateUpdated.addListener(onNavigation);
+}
+
+const OPEN_POPUP_MESSAGE = "lw-open-popup";
+const BOOKMARK_SHORTCUT_GRACE_MS = 1500;
+let bookmarkShortcutAt = 0;
+let openingPopup = false;
+
+async function openActionPopup() {
+  if (openingPopup) return;
+  openingPopup = true;
+  bookmarkShortcutAt = Date.now();
+
+  try {
+    const action = browser.action;
+    if (action?.openPopup) {
+      await action.openPopup();
+      return;
+    }
+  } catch {
+    // Chrome only treats some gestures as valid for openPopup.
+  } finally {
+    setTimeout(() => {
+      openingPopup = false;
+    }, 500);
+  }
+
+  try {
+    await browser.windows.create({
+      url: browser.runtime.getURL("index.html"),
+      type: "popup",
+      width: 420,
+      height: 640,
+      focused: true,
+    });
+  } catch (error) {
+    console.error("Failed to open Linkwarden popup:", error);
+  }
+}
+
+browser.runtime.onMessage.addListener((message) => {
+  if (message?.type !== OPEN_POPUP_MESSAGE) return;
+  void (async () => {
+    const { overrideBookmarkShortcut } = await getConfig();
+    if (overrideBookmarkShortcut === false) return;
+    await openActionPopup();
+  })();
+});
+
+if (hasAPI("bookmarks.onCreated")) {
+  browser.bookmarks.onCreated.addListener((id, bookmark) => {
+    if (!bookmark.url) return;
+    if (Date.now() - bookmarkShortcutAt > BOOKMARK_SHORTCUT_GRACE_MS) return;
+    void browser.bookmarks.remove(id).catch(() => {});
+  });
+}
+
+if (hasAPI("runtime.onStartup")) {
+  browser.runtime.onStartup.addListener(() => {
+    void (async () => {
+      const { id: tabId, url } = await getCurrentTabInfo();
+      scheduleTabBadge(tabId, url);
+    })();
+  });
+}
+
+void (async () => {
+  try {
+    const [tab] = await browser.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    if (tab?.id) {
+      scheduleTabBadge(tab.id, tab.url);
+    }
+  } catch (error) {
+    console.error("Error updating badge on startup:", error);
+  }
+})();
 
 // Omnibox implementation (not available in Safari)
 

--- a/apps/extension/src/pages/Content/index.ts
+++ b/apps/extension/src/pages/Content/index.ts
@@ -1,0 +1,53 @@
+const OPEN_POPUP_MESSAGE = "lw-open-popup";
+const CONFIG_KEY = "linkwarden_config";
+
+let overrideBookmarkShortcut = true;
+
+function readOverride(raw: unknown): boolean {
+  if (typeof raw !== "string") return true;
+  try {
+    return JSON.parse(raw).overrideBookmarkShortcut !== false;
+  } catch {
+    return true;
+  }
+}
+
+void chrome.storage.local.get(CONFIG_KEY).then((result) => {
+  overrideBookmarkShortcut = readOverride(result[CONFIG_KEY]);
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "local" || !changes[CONFIG_KEY]) return;
+  overrideBookmarkShortcut = readOverride(changes[CONFIG_KEY].newValue);
+});
+
+function isBookmarkShortcut(event: KeyboardEvent) {
+  if (event.defaultPrevented || event.repeat || event.altKey || event.shiftKey) {
+    return false;
+  }
+
+  const isD = event.key.toLowerCase() === "d" || event.code === "KeyD";
+  if (!isD) return false;
+
+  const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+  if (isMac) return event.metaKey && !event.ctrlKey;
+  return event.ctrlKey && !event.metaKey;
+}
+
+window.addEventListener(
+  "keydown",
+  (event) => {
+    if (!overrideBookmarkShortcut || !isBookmarkShortcut(event)) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    try {
+      const sent = chrome.runtime.sendMessage({ type: OPEN_POPUP_MESSAGE });
+      void sent?.catch?.(() => {});
+    } catch {
+      // The background script may be asleep; the next keypress retries.
+    }
+  },
+  true
+);

--- a/apps/extension/version.xcconfig
+++ b/apps/extension/version.xcconfig
@@ -4,5 +4,5 @@
 // CURRENT_PROJECT_VERSION is preserved across builds and is yours to edit.
 // Raise it before every App Store Connect upload you archive locally; it
 // must always be higher than the last build Apple accepted.
-MARKETING_VERSION = 1.5.6
+MARKETING_VERSION = 1.5.7
 CURRENT_PROJECT_VERSION = 4

--- a/apps/extension/version.xcconfig
+++ b/apps/extension/version.xcconfig
@@ -4,5 +4,5 @@
 // CURRENT_PROJECT_VERSION is preserved across builds and is yours to edit.
 // Raise it before every App Store Connect upload you archive locally; it
 // must always be higher than the last build Apple accepted.
-MARKETING_VERSION = 1.5.7
+MARKETING_VERSION = 1.5.6
 CURRENT_PROJECT_VERSION = 4

--- a/apps/extension/vite.config.ts
+++ b/apps/extension/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
         main: path.resolve(__dirname, "index.html"),
         options: path.resolve(__dirname, "src/pages/Options/options.html"),
         background: path.resolve(__dirname, "src/pages/Background/index.ts"),
+        content: path.resolve(__dirname, "src/pages/Content/index.ts"),
       },
       output: {
         entryFileNames: "[name].js",

--- a/apps/web/lib/api/controllers/search/searchLinks.ts
+++ b/apps/web/lib/api/controllers/search/searchLinks.ts
@@ -155,37 +155,87 @@ export default async function searchLinks({
   const searchConditions = [];
 
   if (query.searchQueryString) {
-    searchConditions.push({
-      name: {
-        contains: query.searchQueryString,
-        mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
-      },
-    });
+    const tokens = parseSearchTokens(query.searchQueryString);
+    const generalQuery = tokens
+      .filter((t) => t.field === "general")
+      .map((t) => t.value)
+      .join(" ");
+    const urlTokens = tokens.filter((t) => t.field === "url" && !t.isNegative);
 
-    searchConditions.push({
-      url: {
-        contains: query.searchQueryString,
-        mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
-      },
-    });
+    for (const token of urlTokens) {
+      searchConditions.push({
+        url: {
+          contains: token.value,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+    }
 
-    searchConditions.push({
-      description: {
-        contains: query.searchQueryString,
-        mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
-      },
-    });
+    if (generalQuery) {
+      searchConditions.push({
+        name: {
+          contains: generalQuery,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
 
-    searchConditions.push({
-      tags: {
-        some: {
-          name: {
-            contains: query.searchQueryString,
-            mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+      searchConditions.push({
+        url: {
+          contains: generalQuery,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+
+      searchConditions.push({
+        description: {
+          contains: generalQuery,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+
+      searchConditions.push({
+        tags: {
+          some: {
+            name: {
+              contains: generalQuery,
+              mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+            },
           },
         },
-      },
-    });
+      });
+    } else if (!urlTokens.length) {
+      searchConditions.push({
+        name: {
+          contains: query.searchQueryString,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+
+      searchConditions.push({
+        url: {
+          contains: query.searchQueryString,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+
+      searchConditions.push({
+        description: {
+          contains: query.searchQueryString,
+          mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+        },
+      });
+
+      searchConditions.push({
+        tags: {
+          some: {
+            name: {
+              contains: query.searchQueryString,
+              mode: POSTGRES_IS_ENABLED ? "insensitive" : undefined,
+            },
+          },
+        },
+      });
+    }
   }
 
   const accessCondition = await resolveAccessCondition();


### PR DESCRIPTION
## What does this PR do?

Significant changes to improve Browser Extension:
- Fixed icon indicator not showing up properly.
- Added functionality for updating and deleting existing bookmarks.
- Added a hook that overrides the browsers shortcut for bookmarking (Ctrl/Cmd + D).
- Added an option to set a defaultCollection in Browser Extension config.

Related issues:
- Fixes https://github.com/linkwarden/linkwarden/issues/615
- Fixes https://github.com/linkwarden/linkwarden/issues/1826
- Partially fixes https://github.com/linkwarden/linkwarden/issues/1473 by overriding browser extension bookmark functionality.
- Fixes https://github.com/linkwarden/linkwarden/issues/1134


## Visual Demo
A visual demonstration is strongly recommended, for both the original and new change **(video / image)**.

#### Video Demo (if applicable):
- N/A

#### Image Demo (if applicable):
Old vs New:

<img width="313" height="461" alt="image" src="https://github.com/user-attachments/assets/9f5b667b-94f9-4966-95a4-6ad54c9d11f8" />

<img width="310" height="497" alt="image" src="https://github.com/user-attachments/assets/d359890b-11e2-412a-8294-6bb1c8b2ea91" />


<img width="313" height="162" alt="image" src="https://github.com/user-attachments/assets/b8609973-6630-4a74-a48e-c77d07163e57" />

<img width="309" height="304" alt="image" src="https://github.com/user-attachments/assets/354db9e2-8898-4e81-b4fa-e18eb460a762" />



## AI Assistance (Required)
We allow AI-assisted development, but reviewers need transparency to assess risk, maintainability, and correctness.

#### AI usage level (check one)
- [ ] None (no AI used)
- [ ] Light (spellcheck/rewording/comments/docs only)
- [ ] Medium (AI suggested small code changes/snippets that I adapted)
- [x] Heavy (AI significantly shaped the implementation or architecture)

#### Which tool(s) where used?
- Cursor

## What was verified by the author?
- [x] I reviewed **and** understood all AI/human generated code
- [x] I validated behavior locally (tests/manual verification)
- [x] I checked edge cases and failure modes **(in Brave Browser which is Chromium based)**

## Submission Acknowledgement
- [x] I acknowledge that a decent size PR without self-review might be rejected